### PR TITLE
Inets

### DIFF
--- a/Announcement.h
+++ b/Announcement.h
@@ -52,7 +52,7 @@ struct Announcement {
     
     std::string to_sql(){
         return ("'" + prefix.to_cidr() + 
-                "-" + std::to_string(origin) + "'" + 
+                "," + std::to_string(origin) + "'" + 
                 "," + "'" + std::to_string(priority) + "'" + 
                 "," + std::to_string(received_from_asn));
     }

--- a/Announcement.h
+++ b/Announcement.h
@@ -67,7 +67,7 @@ struct Announcement {
 
     std::ostream& to_csv(std::ostream &os){
         //TODO add prefix to_string that combines host and mask
-        os << prefix.to_cidr() << "-" << origin << "," << priority << 
+        os << prefix.to_cidr() << "," << origin << "," << priority << 
             "," << received_from_asn << std::endl;
         return os;
     }

--- a/Extrapolator.cpp
+++ b/Extrapolator.cpp
@@ -30,15 +30,13 @@ void Extrapolator::perform_propagation(bool test, int iteration_size, int max_to
             cout << "Created \"test\" directory" <<endl;
     }
     */
-    //code for making directory in temp space
     
+    // make tmp directory if it does not exist
     bool exists = false;
-
     DIR* dir = opendir("/dev/shm/bgp");
     if(!dir){
         mkdir("/dev/shm/bgp", 0777); 
-    }
-    else{
+    } else {
         closedir(dir);
     }
 

--- a/Extrapolator.cpp
+++ b/Extrapolator.cpp
@@ -139,7 +139,7 @@ void Extrapolator::perform_propagation(bool test, int iteration_size, int max_to
     }
     std::string sql = "CREATE INDEX IF NOT EXISTS ON ";
     sql += RESULTS_TABLE;
-    sql += " USING GIST(prefix inet_ops origin)";
+    sql += " USING GIST(prefix inet_ops, origin)";
     querier->execute(sql, false);
     /*
     for (auto &t : *threads){

--- a/Extrapolator.cpp
+++ b/Extrapolator.cpp
@@ -44,6 +44,7 @@ void Extrapolator::perform_propagation(bool test, int iteration_size, int max_to
 	std::string sql = "DROP TABLE ";
     sql += RESULTS_TABLE;
     sql += + " ;";
+    std::cout << "Dropping results table" << std::endl;
     querier->execute(sql, false);
     sql = "CREATE TABLE ";
     sql += RESULTS_TABLE;
@@ -58,15 +59,17 @@ void Extrapolator::perform_propagation(bool test, int iteration_size, int max_to
     sql += "GRANT ALL ON TABLE ";
     sql += RESULTS_TABLE;
     sql += " TO bgp_user;";
+    std::cout << "Creating results table" << std::endl;
     querier->execute(sql, false);
 
     //Get ROAs from "roas" table (prefix - origin pairs)
+    std::cout << "Selecting prefixes with ROAs..." << std::endl;
     pqxx::result prefixes = querier->select_roa_prefixes(ROAS_TABLE, IPV4);
 
     int row_to_start_group = 0;
     int row_in_group = 0;
     int num_prefixes = prefixes.size();
-    int iteration_num = 1;
+    int iteration_num = 0;
 
     //Continue if not exeeding user defined or record max
 
@@ -128,6 +131,9 @@ void Extrapolator::perform_propagation(bool test, int iteration_size, int max_to
                   as_path->push_back(std::stoul(token));
                 } catch(const std::out_of_range& e) {
                   std::cerr << "Caught out of range error filling path vect, token was: " << token << std::endl; 
+                } catch(const std::invalid_argument& e) {
+                  std::cerr << "Invalid argument filling path vect, token was:"
+                    << token << std::endl;
                 }
                 path_as_string.erase(0,pos + delimiter.length());
             }
@@ -136,6 +142,15 @@ void Extrapolator::perform_propagation(bool test, int iteration_size, int max_to
             } catch(const std::out_of_range& e) {
               std::cerr << "Caught out of range error filling path vect (last), token was: " << token << std::endl; 
               std::cerr << "Path as string was: " << path_as_string << std::endl; 
+            } catch(const std::invalid_argument& e) {
+                  if (path_as_string.length() == 0) {
+                    std::cerr << "Ignoring announcement with empty as_path" <<
+                      std::endl;
+                  } else {
+                    std::cerr << "Invalid argument filling path vect (last), token was:"
+                      << token << std::endl;
+                    std::cerr << "Path as string was: " << path_as_string << std::endl;
+                  }
             }
        
             //if no hop identify accordingly, otherwise use it
@@ -161,6 +176,7 @@ void Extrapolator::perform_propagation(bool test, int iteration_size, int max_to
     sql = "CREATE INDEX ON ";
     sql += RESULTS_TABLE;
     sql += " USING GIST(prefix inet_ops, origin);";
+    std::cout << "Generating index on results..." << std::endl;
     querier->execute(sql, false);
     /*
     for (auto &t : *threads){
@@ -401,13 +417,10 @@ void Extrapolator::save_results(int iteration){
 //    SQLQuerier *thread_querier = new SQLQuerier;
     std::ofstream outfile;
     std::cerr << "Saving Results From Iteration: " << iteration << std::endl;
-    //TODO replace table name with variable changed by make test
-//    querier->insert_results(graph,"extrapolation_results");
     std::string file_name = "/dev/shm/bgp/" + std::to_string(iteration) + ".csv";
     outfile.open(file_name);
     //TODO accomodate for components
     //DONE -- needs testing
-    std::cerr << file_name << std::endl;
     for (auto &as : *graph->ases){
         as.second->stream_announcements(outfile);
     }

--- a/Extrapolator.cpp
+++ b/Extrapolator.cpp
@@ -137,6 +137,10 @@ void Extrapolator::perform_propagation(bool test, int iteration_size, int max_to
         row_in_group++;
         iteration_num++;
     }
+    std::string sql = "CREATE INDEX IF NOT EXISTS ON ";
+    sql += RESULTS_TABLE;
+    sql += " USING GIST(prefix inet_ops origin)";
+    querier->execute(sql, false);
     /*
     for (auto &t : *threads){
         t.join();

--- a/SQLQuerier.cpp
+++ b/SQLQuerier.cpp
@@ -179,7 +179,7 @@ void SQLQuerier::copy_stubs_to_db(std::string file_name){
 }
 
 void SQLQuerier::copy_results_to_db(std::string file_name){
-    std::string sql = std::string("COPY " RESULTS_TABLE "(asn, prefix_origin, priority, received_from_asn)") +
+    std::string sql = std::string("COPY " RESULTS_TABLE "(asn, prefix, origin, priority, received_from_asn)") +
                         "FROM '" + file_name + "' WITH (FORMAT csv)";
     execute(sql);
 }

--- a/TableNames.h
+++ b/TableNames.h
@@ -1,7 +1,7 @@
 #ifndef TABLENAMES_H
 #define TABLENAMES_H
 
-#define RESULTS_TABLE "extrapolation_results"
+#define RESULTS_TABLE "extrapolation_results2"
 #define PEERS_TABLE "peers"
 #define CUSTOMER_PROVIDER_TABLE "customer_providers"
 #define ROAS_TABLE "roas"

--- a/main.cpp
+++ b/main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]) {
     // put actual main code here
     Extrapolator *extrap = new Extrapolator;
     // TODO make 100 an option, make 800k something more reasonable
-    extrap->perform_propagation(true, 100, 800000);
+    extrap->perform_propagation(true, 100, 100);
     delete extrap;
 
     return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]) {
     // put actual main code here
     Extrapolator *extrap = new Extrapolator;
     // TODO make 100 an option, make 800k something more reasonable
-    extrap->perform_propagation(true, 100, 100);
+    extrap->perform_propagation(true, 100, 8000000);
     delete extrap;
 
     return 0;


### PR DESCRIPTION
Change the output database schema so that it uses a Postgresql cidr type for the prefix and a bigint for the origin, instead of storing the two in a string. 

Also add functionality to automatically drop and re-create the table on each run of the extrapolator. 