### PR TITLE
Change CSV output to be about 10x faster

### DIFF
--- a/AS.cpp
+++ b/AS.cpp
@@ -283,7 +283,7 @@ std::ostream& operator<<(std::ostream &os, const AS& as) {
  */
 std::ostream& AS::stream_announcements(std::ostream &os){
     for (auto &ann : *all_anns) {
-        os << asn << ",";
+        os << asn << ',';
         ann.second.to_csv(os);
     }
     return os;

--- a/AS.cpp
+++ b/AS.cpp
@@ -297,7 +297,7 @@ std::ostream& AS::stream_announcements(std::ostream &os){
  */
 std::ostream& AS::stream_depref(std::ostream &os){
     for (auto &ann : *depref_anns) {
-        os << asn << ",";
+        os << asn << ',';
         ann.second.to_csv(os);
     }
     return os;

--- a/Announcement.h
+++ b/Announcement.h
@@ -57,7 +57,7 @@ struct Announcement {
      * @return The output stream parameter for reuse/recursion.
      */ 
     std::ostream& to_csv(std::ostream &os){
-        os << prefix.to_cidr() << "," << origin << "," << received_from_asn << std::endl;
+        os << prefix.to_cidr() << ',' << origin << ',' << received_from_asn << '\n';//std::endl;
         return os;
     }
 };

--- a/Extrapolator.cpp
+++ b/Extrapolator.cpp
@@ -611,9 +611,9 @@ void Extrapolator::save_results(int iteration){
         std::cout << "Saving Inverse Results From Iteration: " << iteration << std::endl;
         for (auto po : *graph->inverse_results){
             for (uint32_t asn : *po.second) {
-                outfile << asn << ","
-                        << po.first.first.to_cidr() << ","
-                        << po.first.second << std::endl;
+                outfile << asn << ','
+                        << po.first.first.to_cidr() << ','
+                        << po.first.second << '\n';
             }
         }
         outfile.close();

--- a/main.cpp
+++ b/main.cpp
@@ -19,6 +19,8 @@ void intro() {
 
 int main(int argc, char *argv[]) {
     using namespace std;   
+    // don't sync iostreams with printf
+    ios_base::sync_with_stdio(false);
     namespace po = boost::program_options;
     // Handle parameters
     po::options_description desc("Allowed options");


### PR DESCRIPTION
I did some reading on iostreams and these simple changes have increased the csv writing speed from roughly 2.5 MB/sec to 30 MB/sec. I tested these changes and they don't appear to break anything. 

Let me know if you have any suggestions for changes, otherwise merge this into master when you're ready. 