### PR TITLE
ROV++ 0.2bis

### DIFF
--- a/ROVppAS.cpp
+++ b/ROVppAS.cpp
@@ -237,7 +237,7 @@ void ROVppAS::process_announcements(bool ran) {
                     // For ROVpp 0.2bis, forward a blackhole ann to customers if there is no alt route.
                     if (pass_rov(ann)) {
                         passed_rov->push_back(ann);
-                        process_announcement(ann);
+                        process_announcement(ann, ran);
                     } else {
                         failed_rov->push_back(ann);
                         Announcement best_alternative_ann = best_alternative_route(ann); 
@@ -246,9 +246,9 @@ void ROVppAS::process_announcements(bool ran) {
                             blackholes->push_back(ann);
                             ann.origin = UNUSED_ASN_FLAG_FOR_BLACKHOLES;
                             ann.received_from_asn = UNUSED_ASN_FLAG_FOR_BLACKHOLES;
-                            process_announcement(ann);
+                            process_announcement(ann, ran);
                         } else {
-                          process_announcement(best_alternative_ann);
+                          process_announcement(best_alternative_ann, ran);
                         }
                     }
                 } else if (policy_vector.at(0) == ROVPPAS_TYPE_ROVPPBP) {

--- a/ROVppAS.cpp
+++ b/ROVppAS.cpp
@@ -226,6 +226,24 @@ void ROVppAS::process_announcements() {
                           process_announcement(best_alternative_ann);
                         }
                     }
+                } else if (policy_vector.at(0) == ROVPPAS_TYPE_ROVPPBIS) {
+                    // For ROVpp 0.2bis, forward a blackhole ann to customers if there is no alt route.
+                    if (pass_rov(ann)) {
+                        passed_rov->push_back(ann);
+                        process_announcement(ann);
+                    } else {
+                        failed_rov->push_back(ann);
+                        Announcement best_alternative_ann = best_alternative_route(ann); 
+                        if (best_alternative_ann == ann) { // if no alternative
+                            // mark as blackholed and accept this announcement
+                            blackholes->push_back(ann);
+                            ann.origin = UNUSED_ASN_FLAG_FOR_BLACKHOLES;
+                            ann.received_from_asn = UNUSED_ASN_FLAG_FOR_BLACKHOLES;
+                            process_announcement(ann);
+                        } else {
+                          process_announcement(best_alternative_ann);
+                        }
+                    }
                 } else if (policy_vector.at(0) == ROVPPAS_TYPE_ROVPPBP) {
                     // For ROVpp 0.3, forward a blackhole ann if there is no alt route.
                     // Also make a preventive announcement if there is an alt route.

--- a/ROVppAS.h
+++ b/ROVppAS.h
@@ -34,6 +34,7 @@
 #define ROVPPAS_TYPE_ROVPP 2      // ROVpp 0.1 (Just Blackholing)
 #define ROVPPAS_TYPE_ROVPPB 3     // ROVpp 0.2 (Blackhole Announcements)
 #define ROVPPAS_TYPE_ROVPPBP 4    // ROVpp 0.3 (Preventive Ann with Blackhole Ann)
+#define ROVPPAS_TYPE_ROVPPBIS 5    // ROVpp 0.2bis (Blackhole Ann to Customers Only)
 
 // Special Constants
 #define UNUSED_ASN_FLAG_FOR_BLACKHOLES 64512  // This is used for ROVpp 0.1+ to 

--- a/ROVppExtrapolator.cpp
+++ b/ROVppExtrapolator.cpp
@@ -333,9 +333,11 @@ void ROVppExtrapolator::send_all_announcements(uint32_t asn,
             auto *recving_as = graph->ases->find(provider_asn)->second;
             auto anns_to_providers_trimmed = anns_to_providers;
             // ROV++ 0.3 do not send preventive announcements to peers or providers
+            // ROV++ 0.2bis do not send blackhole announcements to peers or providers
             if (rovpp_as != NULL &&
                 rovpp_as->policy_vector.size() > 0 &&
-                rovpp_as->policy_vector.at(0) == ROVPPAS_TYPE_ROVPPBP) {
+                (rovpp_as->policy_vector.at(0) == ROVPPAS_TYPE_ROVPPBP ||
+                rovpp_as->policy_vector.at(0) == ROVPPAS_TYPE_ROVPPBIS)) {
                 for (auto ann_pair : *rovpp_as->preventive_anns) {
                     for (auto it = anns_to_providers_trimmed.begin(); it != anns_to_providers_trimmed.end();) {
                         if (ann_pair.first.prefix == it->prefix &&

--- a/ROVppExtrapolator.cpp
+++ b/ROVppExtrapolator.cpp
@@ -406,7 +406,8 @@ void ROVppExtrapolator::send_all_announcements(uint32_t asn,
             auto anns_to_peers_trimmed = anns_to_peers;
             if (rovpp_as != NULL &&
                 rovpp_as->policy_vector.size() > 0 &&
-                rovpp_as->policy_vector.at(0) == ROVPPAS_TYPE_ROVPPBP) {
+                (rovpp_as->policy_vector.at(0) == ROVPPAS_TYPE_ROVPPBP ||
+                rovpp_as->policy_vector.at(0) == ROVPPAS_TYPE_ROVPPBIS)) {
                 for (auto ann_pair : *rovpp_as->preventive_anns) {
                     for (auto it = anns_to_peers_trimmed.begin(); it != anns_to_peers_trimmed.end();) {
                         if (ann_pair.first.prefix == it->prefix &&

--- a/ROVppTest.cpp
+++ b/ROVppTest.cpp
@@ -725,7 +725,7 @@ bool test_rovpp_get_random(){
  * @return True if successful, otherwise false
  */
 bool test_rovpp_add_neighbor(){
-    ROVppAS as = ROVppAS();
+    ROVppAS as = ROVppAS(1);
     as.add_neighbor(1, AS_REL_PROVIDER);
     as.add_neighbor(2, AS_REL_PEER);
     as.add_neighbor(3, AS_REL_CUSTOMER);
@@ -743,7 +743,7 @@ bool test_rovpp_add_neighbor(){
  * @return True if successful, otherwise false
  */
 bool test_rovpp_remove_neighbor(){
-    ROVppAS as = ROVppAS();
+    ROVppAS as = ROVppAS(1);
     as.add_neighbor(1, AS_REL_PROVIDER);
     as.add_neighbor(2, AS_REL_PEER);
     as.add_neighbor(3, AS_REL_CUSTOMER);
@@ -774,7 +774,7 @@ bool test_rovpp_receive_announcements(){
     ann.prefix.netmask = 0xFFFFFF00;
     Prefix<> new_prefix = ann.prefix;
     vect.push_back(ann);
-    ROVppAS as = ROVppAS();
+    ROVppAS as = ROVppAS(1);
     as.receive_announcements(vect);
     if (as.incoming_announcements->size() != 2) { return false; }
     // order really doesn't matter here
@@ -798,7 +798,7 @@ bool test_rovpp_rov_receive_announcements(){
     ann.prefix.netmask = 0xFFFFFF00;
     ann.origin = 666;
     vect.push_back(ann);
-    ROVppAS as = ROVppAS();
+    ROVppAS as = ROVppAS(1);
     // add the attacker and set the policy to ROV
     as.attackers = new std::set<uint32_t>();
     as.attackers->insert(666);
@@ -818,7 +818,7 @@ bool test_rovpp_process_announcement(){
     Announcement ann = Announcement(13796, 0x89630000, 0xFFFF0000, 22742);
     // this function should make a copy of the announcement
     // if it does not, it is incorrect
-    ROVppAS as = ROVppAS();
+    ROVppAS as = ROVppAS(1);
     as.process_announcement(ann);
     Prefix<> old_prefix = ann.prefix;
     ann.prefix.addr = 0x321C9F00;
@@ -868,7 +868,7 @@ bool test_rovpp_process_announcements(){
     Prefix<> ann1_prefix = ann1.prefix;
     Announcement ann2 = Announcement(13796, 0x321C9F00, 0xFFFFFF00, 22742);
     Prefix<> ann2_prefix = ann2.prefix;
-    ROVppAS as = ROVppAS();
+    ROVppAS as = ROVppAS(1);
     // build a vector of announcements
     std::vector<Announcement> vect = std::vector<Announcement>();
     ann1.priority = 100;
@@ -937,8 +937,8 @@ bool test_rovpp_process_announcements(){
  */
 bool test_rovpp_clear_announcements(){
     Announcement ann = Announcement(13796, 0x89630000, 0xFFFF0000, 22742);
-    ROVppAS as = ROVppAS();
-    // if receive_announcement is broken, this test will also be broken
+    // AS must hve a non-zero ASN in order to accept this announcement
+    ROVppAS as = ROVppAS(1);
     as.process_announcement(ann);
     if (as.all_anns->size() != 1) {
         return false;
@@ -957,7 +957,7 @@ bool test_rovpp_clear_announcements(){
 bool test_rovpp_already_received(){
     Announcement ann1 = Announcement(13796, 0x89630000, 0xFFFF0000, 22742);
     Announcement ann2 = Announcement(13796, 0x321C9F00, 0xFFFFFF00, 22742);
-    ROVppAS as = ROVppAS();
+    ROVppAS as = ROVppAS(1);
     // if receive_announcement is broken, this test will also be broken
     as.process_announcement(ann1);
     if (as.already_received(ann1) && !as.already_received(ann2)) {
@@ -1006,7 +1006,7 @@ bool test_rovpp_announcement(){
  */
 bool test_best_alternative_route_chosen() {
     // Initialize AS
-    ROVppAS as = ROVppAS();
+    ROVppAS as = ROVppAS(1);
     as.attackers = new std::set<uint32_t>();
     
     uint32_t attacker_asn = 666;
@@ -1046,7 +1046,8 @@ bool test_best_alternative_route_chosen() {
     
     // See if it ended up with the correct one
     Announcement selected_ann = as.all_anns->find(p1)->second;
-    return selected_ann == a3;
+    // Note, this test is currently broken, correct behavior is choosing a1
+    return selected_ann == a1;
 }
 
 /**
@@ -1057,7 +1058,7 @@ bool test_best_alternative_route_chosen() {
  */
 bool test_best_alternative_route() {
     // Initialize AS
-    ROVppAS as = ROVppAS();
+    ROVppAS as = ROVppAS(1);
     as.attackers = new std::set<uint32_t>();
     
     uint32_t attacker_asn = 666;


### PR DESCRIPTION
Implementation of 0.2bis, where blackholes are only sent to customers. The integer 5 in the database corresponds to this policy. 

Also some unit test fixes. 