### PR TITLE
Re-enabling loop detection for 0.3

### DIFF
--- a/ROVppExtrapolator.cpp
+++ b/ROVppExtrapolator.cpp
@@ -347,6 +347,14 @@ void ROVppExtrapolator::send_all_announcements(uint32_t asn,
                     }
                 }
             }
+	    // Check for loops
+            for (auto it = anns_to_providers_trimmed.begin(); it != anns_to_providers_trimmed.end();) {
+                if (it->alt != 0 && loop_check(it->prefix, *source_as, recving_as->asn, 0)) {
+                    it = anns_to_providers_trimmed.erase(it);
+                } else {
+                    ++it;
+                }
+            }
             recving_as->receive_announcements(anns_to_providers_trimmed);
         }
     }
@@ -429,6 +437,14 @@ void ROVppExtrapolator::send_all_announcements(uint32_t asn,
                     }
                 }
             }
+	    // Check for loops
+            for (auto it = anns_to_peers_trimmed.begin(); it != anns_to_peers_trimmed.end();) {
+                if (it->alt != 0 && loop_check(it->prefix, *source_as, recving_as->asn, 0)) {
+                    it = anns_to_peers_trimmed.erase(it);
+                } else {
+                    ++it;
+                }
+            }
             recving_as->receive_announcements(anns_to_peers_trimmed);
         }
     }
@@ -495,6 +511,14 @@ void ROVppExtrapolator::send_all_announcements(uint32_t asn,
                             ++it;
                         }
                     }
+                }
+            }
+	    // Check for loops
+            for (auto it = anns_to_customers_trimmed.begin(); it != anns_to_customers_trimmed.end();) {
+                if (it->alt != 0 && loop_check(it->prefix, *source_as, recving_as->asn, 0)) {
+                    it = anns_to_customers_trimmed.erase(it);
+                } else {
+                    ++it;
                 }
             }
             // For each customer, give the vector of announcements


### PR DESCRIPTION
Traceback is back and better than ever. 

Now that we have the alt flag set for preventive announcements, we only do traceback when the alt flag is set.  