### PR TITLE
Preliminary full path implementation

### DIFF
--- a/ASTest.cpp
+++ b/ASTest.cpp
@@ -119,8 +119,9 @@ bool test_process_announcement(){
 
     // Check priority
     Prefix<> p = Prefix<>("1.1.1.0", "255.255.255.0");
-    Announcement a1 = Announcement(111, p.addr, p.netmask, 199, 222, false);
-    Announcement a2 = Announcement(111, p.addr, p.netmask, 298, 223, false);
+    std::vector<uint32_t> x; 
+    Announcement a1 = Announcement(111, p.addr, p.netmask, 199, 222, 0, x);
+    Announcement a2 = Announcement(111, p.addr, p.netmask, 298, 223, 0, x);
     as.process_announcement(a1, true);
     as.process_announcement(a2, true);
     if (as.all_anns->find(p)->second.received_from_asn != 223 ||
@@ -130,7 +131,7 @@ bool test_process_announcement(){
     }    
 
     // Check new best announcement
-    Announcement a3 = Announcement(111, p.addr, p.netmask, 299, 224, false);
+    Announcement a3 = Announcement(111, p.addr, p.netmask, 299, 224, 0, x);
     as.process_announcement(a3, true);
     if (as.all_anns->find(p)->second.received_from_asn != 224 ||
         as.depref_anns->find(p)->second.received_from_asn != 223) {

--- a/Announcement.h
+++ b/Announcement.h
@@ -40,11 +40,15 @@ public:
     int64_t tstamp;             // timestamp from mrt file
     // TODO replace with proper templating
     uint32_t policy_index;      // stores the policy index the ann applies
-
+    std::vector<uint32_t> as_path; // stores full as path
+    
     /** Default constructor
      */
-    Announcement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask,
-        uint32_t from_asn, int64_t timestamp = 0) {
+    Announcement(uint32_t aorigin, 
+                 uint32_t aprefix, 
+                 uint32_t anetmask,
+                 uint32_t from_asn, 
+                 int64_t timestamp = 0) {
         prefix.addr = aprefix;
         prefix.netmask = anetmask;
         origin = aorigin;
@@ -57,11 +61,18 @@ public:
     
     /** Priority constructor
      */
-    Announcement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask,
-        uint32_t pr, uint32_t from_asn, int64_t timestamp, bool a_from_monitor = false) 
-        : Announcement(aorigin, aprefix, anetmask, from_asn, timestamp) { 
+    Announcement(uint32_t aorigin, 
+                 uint32_t aprefix, 
+                 uint32_t anetmask,
+                 uint32_t pr, 
+                 uint32_t from_asn, 
+                 int64_t timestamp, 
+                 const std::vector<uint32_t> &path,
+                 bool a_from_monitor = false) 
+        : Announcement(aorigin, aprefix, anetmask, from_asn, timestamp) {
         priority = pr; 
         from_monitor = a_from_monitor;
+        as_path = path;
     }
 
     /** Defines the << operator for the Announcements

--- a/AnnouncementTest.cpp
+++ b/AnnouncementTest.cpp
@@ -9,7 +9,8 @@
  * @ return True for success
  */
 bool test_announcement(){
-    Announcement ann = Announcement(111, 0x01010101, 0xffffff00, 262, 222, false);
+    std::vector<uint32_t> x;
+    Announcement ann = Announcement(111, 0x01010101, 0xffffff00, 262, 222, 0, x, false);
     if (ann.origin != 111 || ann.prefix.addr != 0x01010101 || ann.prefix.netmask != 0xffffff00 || ann.received_from_asn != 222 || ann.priority != 262 || ann.from_monitor != false)
         return false;
     return true;
@@ -20,12 +21,13 @@ bool test_announcement(){
  * @ return True for success 
  */
 bool test_ann_eq_operator(){
-    Announcement a = Announcement(111, 0x01010101, 0xffffff00, 262, 222, false);
-    Announcement b = Announcement(112, 0x01010101, 0xffffff00, 262, 222, false);
-    Announcement c = Announcement(111, 0x01010102, 0xffffff00, 262, 222, false);
-    Announcement d = Announcement(111, 0x01010101, 0xfffffff0, 262, 222, false);
-    Announcement e = Announcement(111, 0x01010101, 0xffffff00, 261, 222, false);
-    Announcement f = Announcement(111, 0x01010101, 0xffffff00, 262, 221, false);
+    std::vector<uint32_t> x;
+    Announcement a = Announcement(111, 0x01010101, 0xffffff00, 262, 222, 0, x, false);
+    Announcement b = Announcement(112, 0x01010101, 0xffffff00, 262, 222, 0, x, false);
+    Announcement c = Announcement(111, 0x01010102, 0xffffff00, 262, 222, 0, x, false);
+    Announcement d = Announcement(111, 0x01010101, 0xfffffff0, 262, 222, 0, x, false);
+    Announcement e = Announcement(111, 0x01010101, 0xffffff00, 261, 222, 0, x, false);
+    Announcement f = Announcement(111, 0x01010101, 0xffffff00, 262, 221, 0, x, false);
     return !((!(a == a)) ||
         (a == b) ||
         (a == c) ||

--- a/ROVppAnnouncement.h
+++ b/ROVppAnnouncement.h
@@ -29,6 +29,7 @@ struct ROVppAnnouncement : public Announcement {
                       uint32_t from_asn, 
                       int64_t timestamp,
                       uint32_t policy,
+                      const std::vector<uint32_t> &path,
                       bool a_from_monitor = false)
                       : Announcement(aorigin,
                                      aprefix,
@@ -36,6 +37,7 @@ struct ROVppAnnouncement : public Announcement {
                                      pr,
                                      from_asn,
                                      timestamp,
+                                     path,
                                      a_from_monitor) {
         policy_index = policy;
         opt_flag = 0;

--- a/ROVppTest.cpp
+++ b/ROVppTest.cpp
@@ -832,8 +832,9 @@ bool test_rovpp_process_announcement(){
 
     // Check priority
     Prefix<> p = Prefix<>("1.1.1.0", "255.255.255.0");
-    Announcement a1 = Announcement(111, p.addr, p.netmask, 199, 222, false);
-    Announcement a2 = Announcement(111, p.addr, p.netmask, 298, 223, false);
+    std::vector<uint32_t> x;
+    Announcement a1 = Announcement(111, p.addr, p.netmask, 199, 222, 0, x);
+    Announcement a2 = Announcement(111, p.addr, p.netmask, 298, 223, 0, x);
     as.process_announcement(a1);
     as.process_announcement(a2);
     if (as.all_anns->find(p)->second.received_from_asn != 223 ||
@@ -843,7 +844,7 @@ bool test_rovpp_process_announcement(){
     }    
 
     // Check new best announcement
-    Announcement a3 = Announcement(111, p.addr, p.netmask, 299, 224, false);
+    Announcement a3 = Announcement(111, p.addr, p.netmask, 299, 224, 0, x);
     as.process_announcement(a3);
     if (as.all_anns->find(p)->second.received_from_asn != 224 ||
         as.depref_anns->find(p)->second.received_from_asn != 223) {
@@ -971,7 +972,8 @@ bool test_rovpp_already_received(){
  * @ return True for success
  */
 bool test_rovpp_announcement(){
-    ROVppAnnouncement ann = ROVppAnnouncement(111, 0x01010101, 0xffffff00, 222, 100, 1);
+    std::vector<uint32_t> x;
+    ROVppAnnouncement ann = ROVppAnnouncement(111, 0x01010101, 0xffffff00, 0, 222, 100, 1, x);
     if (ann.origin != 111 
         || ann.prefix.addr != 0x01010101 
         || ann.prefix.netmask != 0xffffff00 
@@ -983,7 +985,7 @@ bool test_rovpp_announcement(){
         return false;
     }
     
-    ann = ROVppAnnouncement(111, 0x01010101, 0xffffff00, 262, 222, 100, 1, true);
+    ann = ROVppAnnouncement(111, 0x01010101, 0xffffff00, 262, 222, 100, 1, x, true);
     if (ann.origin != 111 
         || ann.prefix.addr != 0x01010101 
         || ann.prefix.netmask != 0xffffff00 
@@ -1022,19 +1024,20 @@ bool test_best_alternative_route_chosen() {
     // The difference between the following three is the received_from_asn
     // Notice the priorities
     // The Announcements will be handled in this order
-    Announcement a1 = Announcement(victim_asn, p1.addr, p1.netmask, 222, 11, false);  // If done incorrectly it will end up with this one
+    std::vector<uint32_t> x;
+    Announcement a1 = Announcement(victim_asn, p1.addr, p1.netmask, 222, 11, 0, x);  // If done incorrectly it will end up with this one
     a1.priority = 293;
-    Announcement a2 = Announcement(victim_asn, p1.addr, p1.netmask, 222, 22, false);  // or this one
+    Announcement a2 = Announcement(victim_asn, p1.addr, p1.netmask, 222, 22, 0, x);  // or this one
     a2.priority = 292;
-    Announcement a3 = Announcement(victim_asn, p1.addr, p1.netmask, 332, 33, false);  // It should end up with this one if done correctly
+    Announcement a3 = Announcement(victim_asn, p1.addr, p1.netmask, 332, 33, 0, x);  // It should end up with this one if done correctly
     a3.priority = 291;
     
     // Subprefix Hijack
     Prefix<> p2 = Prefix<>("1.2.3.0", "255.255.0.0");
     // The difference between the following is the received_from_asn
-    Announcement a4 = Announcement(attacker_asn, p2.addr, p2.netmask, 222, 11, false);  // Should cause best_alternative_route to be called and end up with a2 in RIB
+    Announcement a4 = Announcement(attacker_asn, p2.addr, p2.netmask, 222, 11, 0, x);  // Should cause best_alternative_route to be called and end up with a2 in RIB
     a4.priority = 294;
-    Announcement a5 = Announcement(attacker_asn, p2.addr, p2.netmask, 222, 22, false);  // This cause it to go back a1 again, even though we just saw it conflicts with the previous annoucement (i.e. a4)
+    Announcement a5 = Announcement(attacker_asn, p2.addr, p2.netmask, 222, 22, 0, x);  // This cause it to go back a1 again, even though we just saw it conflicts with the previous annoucement (i.e. a4)
     a5.priority = 295;
     
     // Notice the victim's ann come first, then the attackers
@@ -1073,19 +1076,20 @@ bool test_best_alternative_route() {
     // The difference between the following three is the received_from_asn
     // Notice the priorities
     // The Announcements will be handled in this order
-    Announcement a1 = Announcement(victim_asn, p1.addr, p1.netmask, 222, 11, false);  // If done incorrectly it will end up with this one
+    std::vector<uint32_t> x;
+    Announcement a1 = Announcement(victim_asn, p1.addr, p1.netmask, 222, 11, 0, x);  // If done incorrectly it will end up with this one
     a1.priority = 293;
-    Announcement a2 = Announcement(victim_asn, p1.addr, p1.netmask, 222, 22, false);  // or this one
+    Announcement a2 = Announcement(victim_asn, p1.addr, p1.netmask, 222, 22, 0, x);  // or this one
     a2.priority = 292;
-    Announcement a3 = Announcement(victim_asn, p1.addr, p1.netmask, 332, 33, false);  // It should end up with this one if done correctly
+    Announcement a3 = Announcement(victim_asn, p1.addr, p1.netmask, 332, 33, 0, x);  // It should end up with this one if done correctly
     a3.priority = 291;
     
     // Subprefix Hijack
     Prefix<> p2 = Prefix<>("1.2.3.0", "255.255.0.0");
     // The difference between the following is the received_from_asn
-    Announcement a4 = Announcement(attacker_asn, p2.addr, p2.netmask, 222, 11, false);  // Should cause best_alternative_route to be called and end up with a2 in RIB
+    Announcement a4 = Announcement(attacker_asn, p2.addr, p2.netmask, 222, 11, 0, x);  // Should cause best_alternative_route to be called and end up with a2 in RIB
     a4.priority = 294;
-    Announcement a5 = Announcement(attacker_asn, p2.addr, p2.netmask, 222, 22, false);  // This cause it to go back a1 again, even though we just saw it conflicts with the previous annoucement (i.e. a4)
+    Announcement a5 = Announcement(attacker_asn, p2.addr, p2.netmask, 222, 22, 0, x);  // This cause it to go back a1 again, even though we just saw it conflicts with the previous annoucement (i.e. a4)
     a5.priority = 295;
     
     // Notice the victim's ann come first, then the attackers


### PR DESCRIPTION
Preliminary implementation of full path annoucements. It only handles seeding at the origin (shouldnt be a problem for now). It is slightly modified from my verification version, appending the current asn in send_all_announcements(). 

Keep in mind the path is stored in REVERSE ORDER, {origin->cur_asn}. It is much more efficient to operate on the end of the vector than the front, though we can adjust this if it is a problem.