### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,14 @@ CC=g++
 CPPFLAGS= -Wall -g -std=c++14 -DBOOST_LOG_DYN_LINK
 LDFLAGS= -lpqxx -lpq -lboost_program_options -lboost_unit_test_framework -lboost_log -lboost_filesystem -lboost_thread -lpthread -lboost_system -lboost_log_setup
 OBJECTS := $(patsubst %.cpp,%.o,$(wildcard *.cpp))
+HEADERS := $(wildcard *.h)
+PREFIX = /usr/local
+LOGDIR = /opt/log/bgp-extrapolator
 
 # compile with optimization if not running tests
 all: CPPFLAGS+= -O3
 
-all: $(OBJECTS)
+all: $(OBJECTS) $(HEADERS)
 	$(CC) $(CPPFLAGS) -o bgp-extrapolator $(OBJECTS) $(LDFLAGS)
 
 test: CPPFLAGS+= -DRUN_TESTS=1
@@ -14,9 +17,24 @@ test: CPPFLAGS+= -DRUN_TESTS=1
 test: $(OBJECTS) 
 	$(CC) $(CPPFLAGS) -o bgp-extrapolator $(OBJECTS) $(LDFLAGS)
 
-%.o: %.cpp
+%.o: %.cpp $(HEADERS)
 	$(CC) -c $(CPPFLAGS) $< -o $@
 
-.PHONY: clean
+logdir:
+	mkdir -p $(LOGDIR)
+
+install: $(OBJECTS) logdir
+	install -D bgp-extrapolator $(DESTDIR)$(prefix)/bin/bgp-extrapolator
+
+build: all
+build-arch: all
+build-indep: all
+binary: install
+binary-arch: install
+binary-indep: install
+
+.PHONY: clean distclean
 clean:
-	rm *.o bgp-extrapolator
+	rm *.o bgp-extrapolator || true
+
+distclean: clean


### PR DESCRIPTION
This contains several long overdue updates to the Makefile.
 
Most importantly, header files are now listed as dependencies, so any change in a header file will trigger a rebuild of every object file. This means running `make clean && make -j12` while editing header files is no longer necessary. 

This also adds an install target, so you can `make install` and put the extrapolator you just built on the PATH. 

There is also a logging directory dependency to the install target. With Sam's new logging changes, we might want to have a default logging directory available. 

Lastly, there are some targets at the end that allow packaging into a debian package. I'll be making a new repo for the package metadata shortly. 