### PR TITLE
Multithreaded Results Saving

### DIFF
--- a/include/Extrapolators/BaseExtrapolator.h
+++ b/include/Extrapolators/BaseExtrapolator.h
@@ -191,17 +191,11 @@ public:
      */
     virtual void save_results(int iteration);
 
-    /** Same as save_results, but designed to run in a separate thread
+    /** Thread function to save results
      *
      * @param iteration The current iteration of the propagation
      */
     virtual void save_results_thread(int iteration, int thread_num, int num_threads);
-
-    /** Coordinates threads running save_result_thread
-     *
-     * @param iteration The current iteration of the propagation
-     */
-    virtual void save_results_parallel(int iteration);
 
 };
 #endif

--- a/include/Extrapolators/Extrapolator.h
+++ b/include/Extrapolators/Extrapolator.h
@@ -39,7 +39,6 @@ public:
 
     Extrapolator();
     ~Extrapolator();
-    void save_results(int iteration);
 };
 
 #endif

--- a/include/Extrapolators/Extrapolator.h
+++ b/include/Extrapolators/Extrapolator.h
@@ -39,7 +39,7 @@ public:
 
     Extrapolator();
     ~Extrapolator();
-
+    void save_results(int iteration);
 };
 
 #endif

--- a/include/Tests/Tests.h
+++ b/include/Tests/Tests.h
@@ -89,6 +89,7 @@ bool test_Extrapolator_constructor();
 bool test_propagate_up();
 bool test_propagate_down();
 bool test_propagate_down2();
+bool test_save_results_parallel();
 bool test_give_ann_to_as_path();
 bool test_send_all_announcements();
 

--- a/main.cpp
+++ b/main.cpp
@@ -24,6 +24,8 @@
 #ifndef RUN_TESTS
 #include <iostream>
 #include <boost/program_options.hpp>
+#include <thread>
+#include <semaphore.h>
 
 #include "Logger.h"
 #include "ASes/AS.h"
@@ -43,7 +45,7 @@ void intro() {
 
 int main(int argc, char *argv[]) {
     using namespace std;   
-    // don't sync iostreams with printf
+    // Don't sync iostreams with printf
     ios_base::sync_with_stdio(false);
     namespace po = boost::program_options;
     // Handle parameters
@@ -195,7 +197,6 @@ int main(int argc, char *argv[]) {
         // Clean up
         delete extrap;
     }
-
     return 0;
 }
 #endif // RUN_TESTS

--- a/src/Extrapolators/BaseExtrapolator.cpp
+++ b/src/Extrapolators/BaseExtrapolator.cpp
@@ -28,6 +28,9 @@
 #include <thread>
 #include <chrono>
 #include <iostream>
+#include <vector>
+#include <thread>
+#include <semaphore.h>
 
 #include "Logger.h"
 #include "Extrapolators/BaseExtrapolator.h"
@@ -38,6 +41,7 @@ BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::~BaseExtr
         delete graph;
     if(querier != NULL)
         delete querier;
+    sem_destroy(&worker_thread_count);
 }
 
 template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
@@ -169,6 +173,82 @@ void BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::save
         outfile.close();
         querier->copy_depref_to_db(depref_name);
         std::remove(depref_name.c_str());
+    }
+}
+
+template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
+void BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::save_results_thread(int iteration, int thread_num, int num_threads){
+    sem_wait(&worker_thread_count);
+    int counter = thread_num;
+    // Need a copy of the querier to make a new db connection 
+    SQLQuerierType querier_copy(*querier);
+    querier_copy.open_connection();
+    std::ofstream outfile;
+    std::string file_name = "/dev/shm/bgp/" + std::to_string(iteration) + "_" + std::to_string(thread_num) + ".csv";
+    outfile.open(file_name);
+    
+    // Handle inverse results
+    if (store_invert_results) {
+        for (auto po : *graph->inverse_results){
+            if ((counter = (counter + 1) % num_threads) == 0) {
+                for (uint32_t asn : *po.second) {
+                    outfile << asn << ','
+                            << po.first.first.to_cidr() << ','
+                            << po.first.second << '\n';
+                }
+            }
+        }
+        outfile.close();
+        querier_copy.copy_inverse_results_to_db(file_name);
+    
+    // Handle standard results
+    } else {
+        for (auto &as : *graph->ases){
+            if (counter++ % num_threads == 0) {
+                as.second->stream_announcements(outfile);
+            }
+        }
+        outfile.close();
+        querier_copy.copy_results_to_db(file_name);
+
+    }
+    std::remove(file_name.c_str());
+    
+    // Handle depref results
+    if (store_depref_results) {
+        std::string depref_name = "/dev/shm/bgp/depref" + std::to_string(iteration) + "_" + std::to_string(thread_num) + ".csv";
+        outfile.open(depref_name);
+        for (auto &as : *graph->ases) {
+            if (counter++ % num_threads == 0) {
+                as.second->stream_depref(outfile);
+            }
+        }
+        outfile.close();
+        querier_copy.copy_depref_to_db(depref_name);
+        std::remove(depref_name.c_str());
+    }
+    querier_copy.close_connection();
+    sem_post(&worker_thread_count);
+}
+
+template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
+void BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::save_results_parallel(int iteration){
+    if (store_invert_results) {
+        std::cout << "Saving Inverse Results From Iteration: " << iteration << std::endl;
+    } else {
+        std::cout << "Saving Results From Iteration: " << iteration << std::endl;
+    }
+    if (store_depref_results) {
+        std::cout << "Saving Depref Results From Iteration: " << iteration << std::endl;
+    }
+    std::vector<std::thread> threads;
+    int cpus = std::thread::hardware_concurrency();
+    int max_workers = cpus > 1 ? cpus - 1 : 1;
+    for (int i = 0; i < max_workers; i++) {
+        threads.push_back(std::thread(&BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::save_results_thread, this, iteration, i, max_workers));
+    }
+    for (int i = 0; i < threads.size(); i++) {
+        threads[i].join();
     }
 }
 

--- a/src/Extrapolators/BaseExtrapolator.cpp
+++ b/src/Extrapolators/BaseExtrapolator.cpp
@@ -252,7 +252,7 @@ void BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::save
         // Start the worker threads
         threads.push_back(std::thread(&BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::save_results_thread, this, iteration, i, max_workers));
     }
-    for (int i = 0; i < threads.size(); i++) {
+    for (size_t i = 0; i < threads.size(); i++) {
         // Note, this could be done slightly faster, technically we can start
         // propagating the next iteration once the CSVs are saved, we don't
         // need to wait for the database insertion, but the speedup likely

--- a/src/Extrapolators/BlockedExtrapolator.cpp
+++ b/src/Extrapolators/BlockedExtrapolator.cpp
@@ -218,7 +218,7 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::e
         std::cout << "Propagating..." << std::endl;
         this->propagate_up();
         this->propagate_down();
-        this->save_results_parallel(iteration);
+        this->save_results(iteration);
         this->graph->clear_announcements();
         iteration++;
         

--- a/src/Extrapolators/BlockedExtrapolator.cpp
+++ b/src/Extrapolators/BlockedExtrapolator.cpp
@@ -218,7 +218,8 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::e
         std::cout << "Propagating..." << std::endl;
         this->propagate_up();
         this->propagate_down();
-        this->save_results(iteration);
+        //this->save_results(iteration);
+        this->save_results_parallel(iteration);
         this->graph->clear_announcements();
         iteration++;
         

--- a/src/Extrapolators/BlockedExtrapolator.cpp
+++ b/src/Extrapolators/BlockedExtrapolator.cpp
@@ -218,7 +218,6 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::e
         std::cout << "Propagating..." << std::endl;
         this->propagate_up();
         this->propagate_down();
-        //this->save_results(iteration);
         this->save_results_parallel(iteration);
         this->graph->clear_announcements();
         iteration++;

--- a/src/Extrapolators/Extrapolator.cpp
+++ b/src/Extrapolators/Extrapolator.cpp
@@ -41,6 +41,3 @@ Extrapolator::Extrapolator() : Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_S
 
 Extrapolator::~Extrapolator() { }
 
-void Extrapolator::save_results(int iteration) {
-    save_results_parallel(iteration);
-}

--- a/src/Extrapolators/Extrapolator.cpp
+++ b/src/Extrapolators/Extrapolator.cpp
@@ -40,3 +40,7 @@ Extrapolator::Extrapolator() : Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_S
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_ITERATION_SIZE) { }
 
 Extrapolator::~Extrapolator() { }
+
+void Extrapolator::save_results(int iteration) {
+    save_results_parallel(iteration);
+}

--- a/src/SQLQueriers/SQLQuerier.cpp
+++ b/src/SQLQueriers/SQLQuerier.cpp
@@ -109,7 +109,6 @@ void SQLQuerier::open_connection() {
     try {
         pqxx::connection *conn = new pqxx::connection(stream.str());
         if (conn->is_open()) {
-            std::cout << "Connected to database: " << db_name <<std::endl;
             C = conn;
         } else {
             std::cerr << "Failed to connect to database : " << db_name <<std::endl;

--- a/src/Tests/ExtrapolatorTest.cpp
+++ b/src/Tests/ExtrapolatorTest.cpp
@@ -440,7 +440,7 @@ bool test_save_results_parallel() {
 
     e.querier->clear_results_from_db();
     e.querier->create_results_tbl();
-    e.save_results_parallel(0);
+    e.save_results(0);
 
     return true;
 }

--- a/src/Tests/Tests.cpp
+++ b/src/Tests/Tests.cpp
@@ -112,6 +112,9 @@ BOOST_AUTO_TEST_CASE( Extrapolator_propagate_down ) {
 BOOST_AUTO_TEST_CASE( Extrapolator_propagate_down2 ) {
         BOOST_CHECK( test_propagate_down2() );
 }
+BOOST_AUTO_TEST_CASE( Extrapolator_save_results_parallel ) {
+        BOOST_CHECK( test_save_results_parallel() );
+}
 BOOST_AUTO_TEST_CASE( Extrapolator_send_all_announcements ) {
         BOOST_CHECK( test_send_all_announcements() );
 }


### PR DESCRIPTION
Saving the results of the Extrapolator is the second most time consuming operation it does (propagation is the most time consuming). Speedups here will have a significant impact on the overall runtime, and fortunately it is pretty straightforward to parallelize. 

Timing tests on the mrt_small input table showed a 30% speedup for non-inverted results. 

Credit to jfuruness for suggesting this improvement. 