### PR TITLE
Log parameters

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -130,9 +130,6 @@ int main(int argc, char *argv[]) {
     unsigned int severity_level = vm["severity-level"].as<unsigned int>();
     bool log_std_out = vm["log-std-out"].as<bool>();
     string log_folder = vm["log-folder"].as<string>();
-    if (log_folder != "") {
-        cout << "Logs saved to: " << log_folder << endl;
-    }
     if ((severity_level < 0) || (severity_level > 5)) {
        Logger::init_logger(log_std_out, log_folder, 0);
     } else {

--- a/main.cpp
+++ b/main.cpp
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) {
          "path to a log folder, enables logging into a file, best used for debugging only")
         ("severity-level,c",
          po::value<unsigned int>()->default_value(0),
-         "severity of errors to be logged, from 0 (trace) to 5 (fatal)");
+         "severity of errors to be logged, from 0 (trace) to 5 (fatal)")
         ("config-section", po::value<string>(), "section of the config file");
 
     po::variables_map vm;

--- a/main.cpp
+++ b/main.cpp
@@ -107,9 +107,15 @@ int main(int argc, char *argv[]) {
         ("prop-twice,k",
          po::value<bool>()->default_value(true),
          "flag whether or not to propagate twice")
-        ("log-folder,l",
+        ("log-output,l",
+         po::value<bool>()->default_value(true),
+         "enables logging into the console, best used for debugging only")
+        ("log-folder,g",
          po::value<string>()->default_value(""),
-         "enables the use of logging, best used for debugging only");
+         "path to a log folder, enables logging into a file, best used for debugging only")
+        ("severity-level,c",
+         po::value<unsigned int>()->default_value(0),
+         "severity of errors to be logged, from 0 (trace) to 5 (fatal)");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc,argv, desc), vm);
@@ -119,8 +125,18 @@ int main(int argc, char *argv[]) {
         exit(0);
     }
 
-    // TODO: replace this with command line parsing and such
-    // Logger::init_logger(true, "", 0);
+    // Logging
+    unsigned int severity_level = vm["severity-level"].as<unsigned int>();
+    bool log_output = vm["log-output"].as<bool>();
+    string log_folder = vm["log-folder"].as<string>();
+    if (log_folder != "") {
+        cout << "Logs saved to: " << log_folder << endl;
+    }
+    if ((severity_level < 0) || (severity_level > 5)) {
+       Logger::init_logger(log_output, log_folder, 0);
+    } else {
+       Logger::init_logger(log_output, log_folder, severity_level);
+    }
 
     // Handle intro information
     intro();

--- a/main.cpp
+++ b/main.cpp
@@ -107,7 +107,7 @@ int main(int argc, char *argv[]) {
         ("prop-twice,k",
          po::value<bool>()->default_value(true),
          "flag whether or not to propagate twice")
-        ("log-output,l",
+        ("log-std-out,l",
          po::value<bool>()->default_value(true),
          "enables logging into the console, best used for debugging only")
         ("log-folder,g",
@@ -127,15 +127,15 @@ int main(int argc, char *argv[]) {
 
     // Logging
     unsigned int severity_level = vm["severity-level"].as<unsigned int>();
-    bool log_output = vm["log-output"].as<bool>();
+    bool log_std_out = vm["log-std-out"].as<bool>();
     string log_folder = vm["log-folder"].as<string>();
     if (log_folder != "") {
         cout << "Logs saved to: " << log_folder << endl;
     }
     if ((severity_level < 0) || (severity_level > 5)) {
-       Logger::init_logger(log_output, log_folder, 0);
+       Logger::init_logger(log_std_out, log_folder, 0);
     } else {
-       Logger::init_logger(log_output, log_folder, severity_level);
+       Logger::init_logger(log_std_out, log_folder, severity_level);
     }
 
     // Handle intro information


### PR DESCRIPTION
Added new command line arguments for enabling logging into the console, specifying path to a log folder, and choosing severity of errors to be logged. After parsing, they are passed to `Logger::init_logger`