### PR TITLE
BaseAS tiny_hash

### DIFF
--- a/include/ASes/BaseAS.h
+++ b/include/ASes/BaseAS.h
@@ -107,6 +107,10 @@ public:
 
     virtual ~BaseAS();
     
+    /** Tiny galois field hash with a fixed key of 3.
+    */
+    virtual uint8_t tiny_hash(uint32_t as_number);
+
     /** Generates a random boolean value.
     */
     virtual bool get_random();

--- a/include/ASes/BaseAS.h
+++ b/include/ASes/BaseAS.h
@@ -53,8 +53,6 @@ public:
     uint32_t asn;       // Autonomous System Number
     bool visited;       // Marks something
     int rank;           // Rank in ASGraph heirarchy for propagation 
-    // Random Number Generator
-    std::minstd_rand ran_bool;
     // Defer processing of incoming announcements for efficiency
     std::vector<AnnouncementType> *incoming_announcements;
     // Maps of all announcements stored
@@ -74,7 +72,7 @@ public:
     bool onStack;
     
     // Constructor. Must be in header file.... We like C++ class templates. We like C++ class templates....
-    BaseAS(uint32_t asn, bool store_depref_results, std::map<std::pair<Prefix<>, uint32_t>, std::set<uint32_t>*> *inverse_results) : ran_bool(asn) {
+    BaseAS(uint32_t asn, bool store_depref_results, std::map<std::pair<Prefix<>, uint32_t>, std::set<uint32_t>*> *inverse_results) {
 
         // Set ASN
         this->asn = asn;

--- a/include/ASes/ROVppAS.h
+++ b/include/ASes/ROVppAS.h
@@ -144,11 +144,7 @@ public:
      */
     void withdraw(ROVppAnnouncement &ann);
     void withdraw(ROVppAnnouncement &ann, ROVppAS &neighbor);
-
-    /** Tiny galois field hash with a fixed key of 3.
-    */
-    uint8_t tiny_hash(uint32_t);
-
+    
     void check_preventives(ROVppAnnouncement ann);
     void receive_announcements(std::vector<ROVppAnnouncement> &announcements);
 

--- a/src/ASes/BaseAS.cpp
+++ b/src/ASes/BaseAS.cpp
@@ -37,8 +37,19 @@ BaseAS<AnnouncementType>::~BaseAS() {
 }
 
 template <class AnnouncementType>
+uint8_t BaseAS<AnnouncementType>::tiny_hash(uint32_t as_number) {
+    uint8_t mask = 0xFF;
+    uint8_t value = 0;
+    for (size_t i = 0; i < sizeof(asn); i++) {
+        value = (value ^ (mask & (as_number>>(i * 8)))) * 3;
+    }
+    return value;
+}
+
+template <class AnnouncementType>
 bool BaseAS<AnnouncementType>::get_random() {
-    bool r = (ran_bool() % 2 == 0);
+    //bool r = (ran_bool() % 2 == 0);
+    bool r = (tiny_hash(asn) % 2 == 0);
     return r;
 }
 

--- a/src/ASes/BaseAS.cpp
+++ b/src/ASes/BaseAS.cpp
@@ -48,7 +48,6 @@ uint8_t BaseAS<AnnouncementType>::tiny_hash(uint32_t as_number) {
 
 template <class AnnouncementType>
 bool BaseAS<AnnouncementType>::get_random() {
-    //bool r = (ran_bool() % 2 == 0);
     bool r = (tiny_hash(asn) % 2 == 0);
     return r;
 }

--- a/src/ASes/BaseAS.cpp
+++ b/src/ASes/BaseAS.cpp
@@ -40,7 +40,7 @@ template <class AnnouncementType>
 uint8_t BaseAS<AnnouncementType>::tiny_hash(uint32_t as_number) {
     uint8_t mask = 0xFF;
     uint8_t value = 0;
-    for (size_t i = 0; i < sizeof(asn); i++) {
+    for (size_t i = 0; i < sizeof(as_number); i++) {
         value = (value ^ (mask & (as_number>>(i * 8)))) * 3;
     }
     return value;

--- a/src/ASes/ROVppAS.cpp
+++ b/src/ASes/ROVppAS.cpp
@@ -579,16 +579,6 @@ void ROVppAS::clear_announcements() {
         depref_anns->clear();
 }
 
-uint8_t ROVppAS::tiny_hash(uint32_t as_number) {
-    uint8_t mask = 0xFF;
-    uint8_t value = 0;
-    for (size_t i = 0; i < sizeof(asn); i++) {
-        value = (value ^ (mask & (as_number>>(i * 8)))) * 3;
-    }
-    return value;
-}
-
-
 std::ostream& ROVppAS::stream_blackholes(std:: ostream &os) {
   for (ROVppAnnouncement ann : *blackholes) {
       os << asn << ",";


### PR DESCRIPTION
Moved `tiny_hash()` to BaseAS class. Also, updated `BaseAS::get_random()` implementation to utilize `tiny_hash()`