### PR TITLE
Hotfix from simultaneous merges

### DIFF
--- a/include/Extrapolators/BaseExtrapolator.h
+++ b/include/Extrapolators/BaseExtrapolator.h
@@ -34,8 +34,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fstream>
+#include <thread>
 #include <stdio.h>
 #include <dirent.h>
+#include <semaphore.h>
 
 #include "ASes/AS.h"
 #include "Graphs/ASGraph.h"

--- a/src/ASes/AS.cpp
+++ b/src/ASes/AS.cpp
@@ -6,3 +6,26 @@ AS::AS(uint32_t asn) : AS(asn, false, NULL) { }
 AS::AS() : AS(0, false, NULL) { }
 
 AS::~AS() { }
+
+template<>
+std::ostream& operator<< <Announcement>(std::ostream &os, const BaseAS<Announcement>& as) {
+    os << "ASN: " << as.asn << std::endl << "Rank: " << as.rank
+        << std::endl << "Providers: ";
+    for (auto &provider : *as.providers) {
+        os << provider << ' ';
+    }
+    os << '\n';
+    os << "Peers: ";
+    for (auto &peer : *as.peers) {
+        os << peer << ' ';
+    }
+    os << '\n';
+    os << "Customers: ";
+    for (auto &customer : *as.customers) {
+        os << customer << ' ';
+    }
+    os << '\n';
+    return os;
+}
+
+

--- a/src/ASes/AS.cpp
+++ b/src/ASes/AS.cpp
@@ -7,25 +7,3 @@ AS::AS() : AS(0, false, NULL) { }
 
 AS::~AS() { }
 
-template<>
-std::ostream& operator<< <Announcement>(std::ostream &os, const BaseAS<Announcement>& as) {
-    os << "ASN: " << as.asn << std::endl << "Rank: " << as.rank
-        << std::endl << "Providers: ";
-    for (auto &provider : *as.providers) {
-        os << provider << ' ';
-    }
-    os << '\n';
-    os << "Peers: ";
-    for (auto &peer : *as.peers) {
-        os << peer << ' ';
-    }
-    os << '\n';
-    os << "Customers: ";
-    for (auto &customer : *as.customers) {
-        os << customer << ' ';
-    }
-    os << '\n';
-    return os;
-}
-
-

--- a/src/Tests/ExtrapolatorTest.cpp
+++ b/src/Tests/ExtrapolatorTest.cpp
@@ -417,6 +417,10 @@ bool test_send_all_announcements() {
  */
 bool test_save_results_parallel() {
     Extrapolator e = Extrapolator(false, false, false, "ignored", "test_extrapolation_results", "unused", "unused", "bgp", 10000);
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
     e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
     e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
     e.graph->add_relationship(2, 3, AS_REL_PEER);

--- a/src/Tests/ExtrapolatorTest.cpp
+++ b/src/Tests/ExtrapolatorTest.cpp
@@ -416,11 +416,7 @@ bool test_send_all_announcements() {
  *  Starting propagation at 1, everyone should see the announcement.
  */
 bool test_save_results_parallel() {
-    Extrapolator e = Extrapolator(false, false, false, "ignored", "test_extrapolation_results", "unused", "unused", 10000);
-    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
-    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
-    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
-    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    Extrapolator e = Extrapolator(false, false, false, "ignored", "test_extrapolation_results", "unused", "unused", "bgp", 10000);
     e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
     e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
     e.graph->add_relationship(2, 3, AS_REL_PEER);


### PR DESCRIPTION
A few things that got missed in the merging. 
 - The AS ostream operator needs to be templated
 - Missing semaphore and thread includes when compiling for test
 - Extrapolator initialization updated in results saving test with new signature