### PR TITLE
Prepending in Blocked and ROV++ extrapolators

### DIFF
--- a/include/Tests/Tests.h
+++ b/include/Tests/Tests.h
@@ -93,6 +93,12 @@ bool test_propagate_down2();
 bool test_save_results_parallel();
 bool test_give_ann_to_as_path();
 bool test_send_all_announcements();
+bool test_prepending_priority_back();
+bool test_prepending_priority_middle();
+bool test_prepending_priority_beginning();
+bool test_prepending_priority_back_existing_ann();
+bool test_prepending_priority_middle_existing_ann();
+bool test_prepending_priority_beginning_existing_ann();
 
 // Prototypes for ROVppTest.cpp
 bool test_rovpp_ann_eq_operator();
@@ -123,6 +129,12 @@ bool test_rovpp_tiebreak_override();
 bool test_withdrawal();
 bool test_tiny_hash();
 bool test_rovpp_full_path();
+bool test_rovpp_prepending_priority_back();
+bool test_rovpp_prepending_priority_middle();
+bool test_rovpp_prepending_priority_beginning();
+bool test_rovpp_prepending_priority_back_existing_ann();
+bool test_rovpp_prepending_priority_middle_existing_ann();
+bool test_rovpp_prepending_priority_beginning_existing_ann();
 
 //EZBGPsec
 bool ezbgpsec_test_path_propagation();

--- a/include/Tests/Tests.h
+++ b/include/Tests/Tests.h
@@ -99,6 +99,7 @@ bool test_prepending_priority_beginning();
 bool test_prepending_priority_back_existing_ann();
 bool test_prepending_priority_middle_existing_ann();
 bool test_prepending_priority_beginning_existing_ann();
+bool test_prepending_priority_beginning_existing_ann2();
 
 // Prototypes for ROVppTest.cpp
 bool test_rovpp_ann_eq_operator();
@@ -135,6 +136,7 @@ bool test_rovpp_prepending_priority_beginning();
 bool test_rovpp_prepending_priority_back_existing_ann();
 bool test_rovpp_prepending_priority_middle_existing_ann();
 bool test_rovpp_prepending_priority_beginning_existing_ann();
+bool test_rovpp_prepending_priority_beginning_existing_ann2();
 
 //EZBGPsec
 bool ezbgpsec_test_path_propagation();

--- a/src/Extrapolators/BlockedExtrapolator.cpp
+++ b/src/Extrapolators/BlockedExtrapolator.cpp
@@ -260,52 +260,6 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::g
 
         auto announcement_search = as_on_path->all_anns->find(prefix);
 
-        // Check if already received this prefix
-        if (announcement_search != as_on_path->all_anns->end()) {
-            AnnouncementType& second_announcement = announcement_search->second;
-
-            // If the current timestamp is newer (worse)
-            if (timestamp > second_announcement.tstamp) {
-                // Skip it
-                continue;
-            } else if (timestamp == second_announcement.tstamp) {
-                // Tie breaker for equal timestamp
-                bool keep_first = true;
-                // Random tiebreak if enabled
-                if (this->random_tiebraking) {
-                    keep_first = as_on_path->get_random();
-                }
-
-                // Log annoucements with equal timestamps 
-                // Logger::getInstance().log("Equal_Timestamp") << "Equal Timestamp on announcements. Prefix: " << prefix.to_cidr() << 
-                //     ", rand value: " << keep_first << ", tstamp on announcements: " << timestamp << 
-                //     ", origin on ann_to_check_for: " << as_path->at(path_l-1) << ", origin on stored announcement: " << second_announcement.origin;
-
-                // First come, first saved if random is disabled
-                if (keep_first) {
-                    continue;
-                } else {
-                    // Position of previous AS on path
-                    uint32_t pos = path_l - i + 1;
-                    // Prepending check, use original priority
-                    if (pos < path_l && as_path->at(pos) == as_on_path->asn) {
-                        continue;
-                    }
-                    as_on_path->delete_ann(prefix);
-                }
-            } else {
-                // Log announcements that arent handled by sorting
-                // Logger::getInstance().log("Unsorted_Announcements") 
-                //     << "This announcement is being deleted and is not handled by sorting." 
-                //     << " Prefix: " << prefix.to_cidr() 
-                //     << ", tstamp: " << timestamp 
-                //     << ", origin: " << as_path->at(path_l-1);
-
-                // Delete worse MRT announcement, proceed with seeding
-                as_on_path->delete_ann(prefix);
-            }
-        }
-        
         // If ASes in the path aren't neighbors (data is out of sync)
         bool broken_path = false;
 
@@ -328,6 +282,61 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::g
         // This is how priority is calculated
         uint32_t path_len_weighted = 100 - (i - 1);
         uint32_t priority = received_from + path_len_weighted;
+
+        // Check if already received this prefix
+        if (announcement_search != as_on_path->all_anns->end()) {
+            AnnouncementType& second_announcement = announcement_search->second;
+
+            // If the current timestamp is newer (worse)
+            if (timestamp > second_announcement.tstamp) {
+                // Skip it
+                continue;
+            } else if (timestamp == second_announcement.tstamp) {
+                // Position of previous AS on path
+                uint32_t pos = path_l - i + 1;
+
+                // Skip announcement if there exists one with a higher priority
+                if (pos < path_l) {
+                    ASType *previous_as = this->graph->ases->find(as_path->at(pos))->second;
+                    if (previous_as->all_anns->find(prefix)->second.priority > priority) {
+                        continue;
+                    }
+                }
+
+                // Tie breaker for equal timestamp
+                bool keep_first = true;
+                // Random tiebreak if enabled
+                if (this->random_tiebraking) {
+                    keep_first = as_on_path->get_random();
+                }
+
+                // Log annoucements with equal timestamps 
+                // Logger::getInstance().log("Equal_Timestamp") << "Equal Timestamp on announcements. Prefix: " << prefix.to_cidr() << 
+                //     ", rand value: " << keep_first << ", tstamp on announcements: " << timestamp << 
+                //     ", origin on ann_to_check_for: " << as_path->at(path_l-1) << ", origin on stored announcement: " << second_announcement.origin;
+
+                // First come, first saved if random is disabled
+                if (keep_first) {
+                    continue;
+                } else {
+                    // Prepending check, use original priority
+                    if (pos < path_l && as_path->at(pos) == as_on_path->asn) {
+                        continue;
+                    }
+                    as_on_path->delete_ann(prefix);
+                }
+            } else {
+                // Log announcements that arent handled by sorting
+                // Logger::getInstance().log("Unsorted_Announcements") 
+                //     << "This announcement is being deleted and is not handled by sorting." 
+                //     << " Prefix: " << prefix.to_cidr() 
+                //     << ", tstamp: " << timestamp 
+                //     << ", origin: " << as_path->at(path_l-1);
+
+                // Delete worse MRT announcement, proceed with seeding
+                as_on_path->delete_ann(prefix);
+            }
+        }
         
         uint32_t received_from_asn = 0;
         // If this AS is the origin

--- a/src/Extrapolators/ROVppExtrapolator.cpp
+++ b/src/Extrapolators/ROVppExtrapolator.cpp
@@ -135,6 +135,7 @@ void ROVppExtrapolator::give_ann_to_as_path(std::vector<uint32_t>* as_path,
     }
     
     uint32_t i = 0;
+    uint32_t path_l = as_path->size();
     uint32_t origin_asn = as_path->back();
     
     // Announcement at origin for checking along the path
@@ -161,16 +162,7 @@ void ROVppExtrapolator::give_ann_to_as_path(std::vector<uint32_t>* as_path,
         cur_path.insert(cur_path.begin(), asn_on_path);
         // Find the current AS on the path
         ROVppAS *as_on_path = graph->ases->find(asn_on_path)->second;
-        // Check if already received this prefix
-        if (as_on_path->already_received(ann_to_check_for)) {
-            // update path vector
-            if (cur_path.back() == as_on_path->asn) {
-                continue;
-            }
-            // Find the already received announcement and delete it
-            as_on_path->delete_ann(ann_to_check_for);
-        }
-        
+
         // If ASes in the path aren't neighbors (data is out of sync)
         bool broken_path = false;
 
@@ -190,10 +182,36 @@ void ROVppExtrapolator::give_ann_to_as_path(std::vector<uint32_t>* as_path,
             }
         }
 
-
         // This is how priority is calculated
         uint32_t path_len_weighted = 100 - (i - 1);
         uint32_t priority = received_from + path_len_weighted;
+
+        // Check if already received this prefix
+        if (as_on_path->already_received(ann_to_check_for)) {
+            // update path vector
+            if (cur_path.back() == as_on_path->asn) {
+                continue;
+            }
+
+            // Position of previous AS on path
+            uint32_t pos = path_l - i + 1;
+
+            // Skip announcement if there exists one with a higher priority
+            if (pos < path_l) {
+                ROVppAS *previous_as = this->graph->ases->find(as_path->at(pos))->second;
+                if (previous_as->all_anns->find(prefix)->second.priority > priority) {
+                    continue;
+                }
+            }
+
+            // Prepending check, use original priority
+            if (pos < path_l && as_path->at(pos) == as_on_path->asn) {
+                continue;
+            }
+
+            // Find the already received announcement and delete it
+            as_on_path->delete_ann(ann_to_check_for);
+        }
 
         uint32_t received_from_asn = 0;
         

--- a/src/Extrapolators/ROVppExtrapolator.cpp
+++ b/src/Extrapolators/ROVppExtrapolator.cpp
@@ -194,18 +194,19 @@ void ROVppExtrapolator::give_ann_to_as_path(std::vector<uint32_t>* as_path,
             }
 
             // Position of previous AS on path
-            uint32_t pos = path_l - i + 1;
+            uint32_t prevPos = path_l - i + 1;
+
+            // Position of the current AS on path
+            uint32_t currPos = path_l - i;
 
             // Skip announcement if there exists one with a higher priority
-            if (pos < path_l) {
-                ROVppAS *previous_as = this->graph->ases->find(as_path->at(pos))->second;
-                if (previous_as->all_anns->find(prefix)->second.priority > priority) {
-                    continue;
-                }
+            ROVppAS *current_as = this->graph->ases->find(as_path->at(currPos))->second;
+            if (current_as->all_anns->find(prefix)->second.priority > priority) {
+                continue;
             }
 
             // Prepending check, use original priority
-            if (pos < path_l && as_path->at(pos) == as_on_path->asn) {
+            if (prevPos < path_l && prevPos >= 0 && as_path->at(prevPos) == as_on_path->asn) {
                 continue;
             }
 

--- a/src/Tests/ExtrapolatorTest.cpp
+++ b/src/Tests/ExtrapolatorTest.cpp
@@ -444,3 +444,279 @@ bool test_save_results_parallel() {
 
     return true;
 }
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 3, 2, 5]. This shouldn't change the priority since prepending is in the back of the path. 
+ */
+bool test_prepending_priority_back() {
+    Extrapolator e = Extrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "prepending_priority_back failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 2, 5]. This should reduce the priority at 3. 
+ */
+bool test_prepending_priority_middle() {
+    Extrapolator e = Extrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 197) {
+        std::cerr << "prepending_priority_middle failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 5, 5]. This should reduce the priority at 3 and 5. 
+ */
+bool test_prepending_priority_beginning() {
+    Extrapolator e = Extrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 298 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 197) {
+        std::cerr << "prepending_priority_end failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 3, 2, 5] with an existing announcement at those ASes. This shouldn't change the priority since prepending is in the back of the path.  
+ */
+bool test_prepending_priority_back_existing_ann() {
+    Extrapolator e = Extrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2);
+
+    std::vector<uint32_t> *as_path_b = new std::vector<uint32_t>();
+    as_path_b->push_back(3);
+    as_path_b->push_back(3);
+    as_path_b->push_back(2);
+    as_path_b->push_back(5);
+    e.give_ann_to_as_path(as_path_b, p, 2);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "prepending_priority_back_existing_ann failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 2, 5] with an existing announcement at those ASes. This shouldn't change the priority since the existing announcement has higher priority.  
+ */
+bool test_prepending_priority_middle_existing_ann() {
+    Extrapolator e = Extrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2);
+
+    std::vector<uint32_t> *as_path_b = new std::vector<uint32_t>();
+    as_path_b->push_back(3);
+    as_path_b->push_back(2);
+    as_path_b->push_back(2);
+    as_path_b->push_back(5);
+    e.give_ann_to_as_path(as_path_b, p, 2);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "prepending_priority_middle_existing_ann failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 5, 5] with an existing announcement at those ASes. This shouldn't change the priority since the existing announcement has higher priority.  
+ */
+bool test_prepending_priority_beginning_existing_ann() {
+    Extrapolator e = Extrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2);
+    
+    std::vector<uint32_t> *as_path_b = new std::vector<uint32_t>();
+    as_path_b->push_back(3);
+    as_path_b->push_back(2);
+    as_path_b->push_back(5);
+    as_path_b->push_back(5);
+    e.give_ann_to_as_path(as_path_b, p, 2);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "prepending_priority_beginning_existing_ann failed." << std::endl;
+        return false;
+    }
+    
+    return true;
+}

--- a/src/Tests/ROVppTests.cpp
+++ b/src/Tests/ROVppTests.cpp
@@ -1740,3 +1740,59 @@ bool test_rovpp_prepending_priority_beginning_existing_ann() {
     
     return true;
 }
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 5, 5] with an existing announcement at those ASes. This should change the priority since the existing announcement has lower priority.  
+ */
+bool test_rovpp_prepending_priority_beginning_existing_ann2() {
+    ROVppExtrapolator e = ROVppExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 298 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 197) {
+        std::cerr << "rovpp_prepending_priority_beginning_existing_ann2 failed." << std::endl;
+        return false;
+    }
+
+    std::vector<uint32_t> *as_path_b = new std::vector<uint32_t>();
+    as_path_b->push_back(3);
+    as_path_b->push_back(2);
+    as_path_b->push_back(5);
+    e.give_ann_to_as_path(as_path_b, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "rovpp_prepending_priority_beginning_existing_ann2 failed." << std::endl;
+        return false;
+    }
+    
+    return true;
+}

--- a/src/Tests/ROVppTests.cpp
+++ b/src/Tests/ROVppTests.cpp
@@ -353,7 +353,7 @@ bool test_rovpp_give_ann_to_as_path() {
     //}
     
     // Test prepending calculation
-    if (e.graph->ases->find(2)->second->loc_rib->find(p)->second.priority != 298) {
+    if (e.graph->ases->find(2)->second->loc_rib->find(p)->second.priority != 299) {
         std::cerr << "Priority calculation in loc_rib failed" << std::endl;
         std::cerr << e.graph->ases->find(2)->second->loc_rib->find(p)->second.priority << std::endl;
         return false;
@@ -1462,5 +1462,281 @@ bool test_tiny_hash() {
     std::cout << (int) ROVppAS(3).tiny_hash(3) << std::endl;
     std::cout << (int) ROVppAS(4).tiny_hash(4) << std::endl;
     std::cout << (int) ROVppAS(5).tiny_hash(5) << std::endl;
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 3, 2, 5]. This shouldn't change the priority since prepending is in the back of the path. 
+ */
+bool test_rovpp_prepending_priority_back() {
+    ROVppExtrapolator e = ROVppExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "rovpp_prepending_priority_back failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 2, 5]. This should reduce the priority at 3. 
+ */
+bool test_rovpp_prepending_priority_middle() {
+    ROVppExtrapolator e = ROVppExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 197) {
+        std::cerr << "rovpp_prepending_priority_middle failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 5, 5]. This should reduce the priority at 3 and 5. 
+ */
+bool test_rovpp_prepending_priority_beginning() {
+    ROVppExtrapolator e = ROVppExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 298 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 197) {
+        std::cerr << "rovpp_prepending_priority_end failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 3, 2, 5] with an existing announcement at those ASes. This shouldn't change the priority since prepending is in the back of the path.  
+ */
+bool test_rovpp_prepending_priority_back_existing_ann() {
+    ROVppExtrapolator e = ROVppExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+
+    std::vector<uint32_t> *as_path_b = new std::vector<uint32_t>();
+    as_path_b->push_back(3);
+    as_path_b->push_back(3);
+    as_path_b->push_back(2);
+    as_path_b->push_back(5);
+    e.give_ann_to_as_path(as_path_b, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "rovpp_prepending_priority_back_existing_ann failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 2, 5] with an existing announcement at those ASes. This shouldn't change the priority since the existing announcement has higher priority.  
+ */
+bool test_rovpp_prepending_priority_middle_existing_ann() {
+    ROVppExtrapolator e = ROVppExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+    
+    std::vector<uint32_t> *as_path_b = new std::vector<uint32_t>();
+    as_path_b->push_back(3);
+    as_path_b->push_back(2);
+    as_path_b->push_back(2);
+    as_path_b->push_back(5);
+    e.give_ann_to_as_path(as_path_b, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "rovpp_prepending_priority_middle_existing_ann failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 5, 5] with an existing announcement at those ASes. This shouldn't change the priority since the existing announcement has higher priority.  
+ */
+bool test_rovpp_prepending_priority_beginning_existing_ann() {
+    ROVppExtrapolator e = ROVppExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+
+    std::vector<uint32_t> *as_path_b = new std::vector<uint32_t>();
+    as_path_b->push_back(3);
+    as_path_b->push_back(2);
+    as_path_b->push_back(5);
+    as_path_b->push_back(5);
+    e.give_ann_to_as_path(as_path_b, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "rovpp_prepending_priority_beginning_existing_ann failed." << std::endl;
+        return false;
+    }
+    
     return true;
 }

--- a/src/Tests/Tests.cpp
+++ b/src/Tests/Tests.cpp
@@ -147,6 +147,9 @@ BOOST_AUTO_TEST_CASE( Extrapolator_prepending_priority_middle_existing_ann ) {
 BOOST_AUTO_TEST_CASE( Extrapolator_prepending_priority_beginning_existing_ann ) {
         BOOST_CHECK( test_prepending_priority_beginning_existing_ann() );
 }
+BOOST_AUTO_TEST_CASE( Extrapolator_prepending_priority_beginning_existing_ann2 ) {
+        BOOST_CHECK( test_prepending_priority_beginning_existing_ann2() );
+}
 
 // ROVpp
 BOOST_AUTO_TEST_CASE( Announcement_eqality_operator ) {
@@ -246,6 +249,9 @@ BOOST_AUTO_TEST_CASE( ROVpp_prepending_priority_middle_existing_ann ) {
 }
 BOOST_AUTO_TEST_CASE( ROVpp_prepending_priority_beginning_existing_ann ) {
         BOOST_CHECK( test_rovpp_prepending_priority_beginning_existing_ann() );
+}
+BOOST_AUTO_TEST_CASE( ROVpp_prepending_priority_beginning_existing_ann2 ) {
+        BOOST_CHECK( test_rovpp_prepending_priority_beginning_existing_ann2() );
 }
 
 //EZBGPsec Tests

--- a/src/Tests/Tests.cpp
+++ b/src/Tests/Tests.cpp
@@ -129,6 +129,24 @@ BOOST_AUTO_TEST_CASE( Extrapolator_save_results_parallel ) {
 BOOST_AUTO_TEST_CASE( Extrapolator_send_all_announcements ) {
         BOOST_CHECK( test_send_all_announcements() );
 }
+BOOST_AUTO_TEST_CASE( Extrapolator_prepending_priority_back ) {
+        BOOST_CHECK( test_prepending_priority_back() );
+}
+BOOST_AUTO_TEST_CASE( Extrapolator_prepending_priority_middle ) {
+        BOOST_CHECK( test_prepending_priority_middle() );
+}
+BOOST_AUTO_TEST_CASE( Extrapolator_prepending_priority_beginning ) {
+        BOOST_CHECK( test_prepending_priority_beginning() );
+}
+BOOST_AUTO_TEST_CASE( Extrapolator_prepending_priority_back_existing_ann ) {
+        BOOST_CHECK( test_prepending_priority_back_existing_ann() );
+}
+BOOST_AUTO_TEST_CASE( Extrapolator_prepending_priority_middle_existing_ann ) {
+        BOOST_CHECK( test_prepending_priority_middle_existing_ann() );
+}
+BOOST_AUTO_TEST_CASE( Extrapolator_prepending_priority_beginning_existing_ann ) {
+        BOOST_CHECK( test_prepending_priority_beginning_existing_ann() );
+}
 
 // ROVpp
 BOOST_AUTO_TEST_CASE( Announcement_eqality_operator ) {
@@ -210,6 +228,24 @@ BOOST_AUTO_TEST_CASE( ROVpp_test_tiny_hash ) {
 }
 BOOST_AUTO_TEST_CASE( ROVpp_test_full_path ) {
         BOOST_CHECK( test_rovpp_full_path() );
+}
+BOOST_AUTO_TEST_CASE( ROVpp_prepending_priority_back ) {
+        BOOST_CHECK( test_rovpp_prepending_priority_back() );
+}
+BOOST_AUTO_TEST_CASE( ROVpp_prepending_priority_middle ) {
+        BOOST_CHECK( test_rovpp_prepending_priority_middle() );
+}
+BOOST_AUTO_TEST_CASE( ROVpp_prepending_priority_beginning ) {
+        BOOST_CHECK( test_rovpp_prepending_priority_beginning() );
+}
+BOOST_AUTO_TEST_CASE( ROVpp_prepending_priority_back_existing_ann ) {
+        BOOST_CHECK( test_rovpp_prepending_priority_back_existing_ann() );
+}
+BOOST_AUTO_TEST_CASE( ROVpp_prepending_priority_middle_existing_ann ) {
+        BOOST_CHECK( test_rovpp_prepending_priority_middle_existing_ann() );
+}
+BOOST_AUTO_TEST_CASE( ROVpp_prepending_priority_beginning_existing_ann ) {
+        BOOST_CHECK( test_rovpp_prepending_priority_beginning_existing_ann() );
 }
 
 //EZBGPsec Tests


### PR DESCRIPTION
I fixed prepending behavior in those extrapolators and created a bunch of tests for it.
give_ann_to_as_path in both Blocked and ROV++ extrapolators now compares priority when there are announcements with the same prefix and timestamp. 
