### PR TITLE
Automatic multihomed mode

### DIFF
--- a/include/Extrapolators/BlockedExtrapolator.h
+++ b/include/Extrapolators/BlockedExtrapolator.h
@@ -2,7 +2,7 @@
 #define BLOCKED_EXTRAPOLATOR_H
 
 #define DEFAULT_ITERATION_SIZE 50000
-#define DEFAULT_MH_MODE 0
+#define DEFAULT_MH_MODE 1
 
 #include "Extrapolators/BaseExtrapolator.h"
 

--- a/include/Tests/Tests.h
+++ b/include/Tests/Tests.h
@@ -100,6 +100,7 @@ bool test_save_results_parallel();
 bool test_give_ann_to_as_path();
 bool test_send_all_announcements();
 bool test_send_all_announcements2();
+bool test_send_all_announcements3();
 bool test_send_all_announcements_no_multihomed();
 bool test_send_all_announcements_multihomed_standard1();
 bool test_send_all_announcements_multihomed_standard2();

--- a/include/Tests/Tests.h
+++ b/include/Tests/Tests.h
@@ -87,15 +87,20 @@ bool test_combine_components();
 
 // Prototypes for ExtrapolatorTest.cpp
 bool test_Extrapolator_constructor();
+bool test_propagate_up_no_multihomed();
 bool test_propagate_up();
 bool test_propagate_up_multihomed_standard();
 bool test_propagate_up_multihomed_peer_mode();
+bool test_propagate_down_no_multihomed();
+bool test_propagate_down_no_multihomed2();
 bool test_propagate_down();
 bool test_propagate_down2();
 bool test_propagate_down_multihomed_standard();
 bool test_save_results_parallel();
 bool test_give_ann_to_as_path();
 bool test_send_all_announcements();
+bool test_send_all_announcements2();
+bool test_send_all_announcements_no_multihomed();
 bool test_send_all_announcements_multihomed_standard1();
 bool test_send_all_announcements_multihomed_standard2();
 bool test_send_all_announcements_multihomed_peer_mode1();

--- a/main.cpp
+++ b/main.cpp
@@ -123,7 +123,7 @@ int main(int argc, char *argv[]) {
          "exclude all announcements from a particular ASN")
         ("mh-propagation-mode", 
          po::value<uint32_t>()->default_value(DEFAULT_MH_MODE),
-         "enables multi-home propagation mode, 1 - no propagation from mh, 2 - propagation from mh to peers");
+         "multi-home propagation mode, 0 - off, 1 - propagate from mh to providers in some cases (automatic), 2 - no propagation from mh, 3 - propagation from mh to peers");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc,argv, desc), vm);

--- a/src/Extrapolators/BlockedExtrapolator.cpp
+++ b/src/Extrapolators/BlockedExtrapolator.cpp
@@ -379,19 +379,29 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::s
     // Get the AS that is sending it's announcements
     auto *source_as = this->graph->ases->find(asn)->second;
 
-    // Don't propagate from multihomed
-    if (mh_mode == 1){
+    // If to_customers = true and the AS is multihomed, return now for efficiency
+    if (mh_mode == 1) {
         // Check if AS is multihomed
         if (source_as->customers->empty()) {
-        return;
+            if (to_customers) {
+                return;
+            }
+        }
+    }
+
+    // Don't propagate from multihomed
+    if (mh_mode == 2) {
+        // Check if AS is multihomed
+        if (source_as->customers->empty()) {
+            return;
         }
     }
 
     // Only propagate to peers from multihomed
-    if (mh_mode == 2) {
+    if (mh_mode == 3) {
             // Check if AS is multihomed
             if (source_as->customers->empty()) {
-                if (to_peers){
+                if (to_peers) {
                     to_providers = false;
                     to_customers = false;
                 } else {
@@ -413,33 +423,53 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::s
             if (ann.second.priority < 200) {
                 continue;
             }
-            
-            // Set the priority of the announcement at destination 
-            uint32_t old_priority = ann.second.priority;
-            uint32_t path_len_weight = old_priority % 100;
-            if (path_len_weight == 0) {
-                // For MRT ann at origin: old_priority = 400
-                path_len_weight = 99;
-            } else {
-                // Sub 1 for the current hop
-                path_len_weight -= 1;
+
+            // Automatic multihomed mode
+            // Propagate an announcement to providers if there are some that haven't received an announcement from that prefix with origin = current asn
+            uint32_t providers_with_ann = 0;
+            if (mh_mode == 1) {
+                // Check if AS is multihomed
+                if (source_as->customers->empty()) {
+                    // Check if all providers have the announcement
+                    for (uint32_t provider_asn : *source_as->providers) {
+                        auto *recving_as = this->graph->ases->find(provider_asn)->second;
+                        for (auto &recving_as_ann : *recving_as->all_anns) {
+                            if (recving_as_ann.second.origin == ann.second.origin && recving_as_ann.second.prefix.addr == ann.second.prefix.addr && recving_as_ann.second.prefix.netmask == ann.second.prefix.netmask) {
+                                providers_with_ann++;
+                            }
+                        }
+                    }
+                }
+            } 
+            // If there are providers that don't have the announcement, propagate to providers
+            if (providers_with_ann < source_as->providers->size()) {
+                // Set the priority of the announcement at destination 
+                uint32_t old_priority = ann.second.priority;
+                uint32_t path_len_weight = old_priority % 100;
+                if (path_len_weight == 0) {
+                    // For MRT ann at origin: old_priority = 400
+                    path_len_weight = 99;
+                } else {
+                    // Sub 1 for the current hop
+                    path_len_weight -= 1;
+                }
+                uint32_t priority = 200 + path_len_weight;
+                
+                AnnouncementType temp = AnnouncementType(ann.second);
+                temp.priority = priority;
+                temp.from_monitor = false;
+                temp.received_from_asn = asn;
+
+                // Push announcement with new priority to ann vector
+                // anns_to_providers.push_back(AnnouncementType(ann.second.origin,
+                //                                          ann.second.prefix.addr,
+                //                                          ann.second.prefix.netmask,
+                //                                          priority,
+                //                                          asn,
+                //                                          ann.second.tstamp));
+
+                anns_to_providers.push_back(temp);
             }
-            uint32_t priority = 200 + path_len_weight;
-            
-            AnnouncementType temp = AnnouncementType(ann.second);
-            temp.priority = priority;
-            temp.from_monitor = false;
-            temp.received_from_asn = asn;
-
-            // Push announcement with new priority to ann vector
-            // anns_to_providers.push_back(AnnouncementType(ann.second.origin,
-            //                                          ann.second.prefix.addr,
-            //                                          ann.second.prefix.netmask,
-            //                                          priority,
-            //                                          asn,
-            //                                          ann.second.tstamp));
-
-            anns_to_providers.push_back(temp);
         }
         // Send the vector of assembled announcements
         for (uint32_t provider_asn : *source_as->providers) {

--- a/src/Tests/ExtrapolatorTest.cpp
+++ b/src/Tests/ExtrapolatorTest.cpp
@@ -152,7 +152,7 @@ bool test_give_ann_to_as_path() {
     return true;
 }
 
-/** Test propagating up in the following test graph.
+/** Test propagating up without multihomed support in the following test graph.
  *  Horizontal lines are peer relationships, vertical lines are customer-provider
  * 
  *    1
@@ -163,8 +163,9 @@ bool test_give_ann_to_as_path() {
  * 
  *  Starting propagation at 5, only 4 and 7 should not see the announcement.
  */
-bool test_propagate_up() {
-    Extrapolator e = Extrapolator();
+bool test_propagate_up_no_multihomed() {
+    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -211,6 +212,65 @@ bool test_propagate_up() {
     return true;
 }
 
+/** Test propagating up with automatic multihomed mode (default behaviour) in the following test graph.
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2---3
+ *   /|    \
+ *  4 5--6  7
+ *
+ *  Starting propagation at 5, everyone but 4 and 7 should see the announcement.
+ */
+bool test_propagate_up() {
+    Extrapolator e = Extrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(7, 3, AS_REL_PROVIDER);
+    e.graph->add_relationship(3, 7, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+
+    e.graph->decide_ranks();
+    
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    ann.from_monitor = true;
+    ann.priority = 290;
+    e.graph->ases->find(5)->second->process_announcement(ann, true);
+    e.propagate_up();
+
+    // Check all announcements are propagted
+    if (!(e.graph->ases->find(1)->second->all_anns->size() == 1 &&
+          e.graph->ases->find(2)->second->all_anns->size() == 1 &&
+          e.graph->ases->find(3)->second->all_anns->size() == 1 &&
+          e.graph->ases->find(4)->second->all_anns->size() == 0 &&
+          e.graph->ases->find(5)->second->all_anns->size() == 1 &&
+          e.graph->ases->find(6)->second->all_anns->size() == 1 &&
+          e.graph->ases->find(7)->second->all_anns->size() == 0)) {
+        std::cerr << "test_propagate_up_multihomed_automatic failed... Not all ASes have refrence when they should.." << std::endl;
+        return false;
+    }
+    
+    // Check propagation priority calculation
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 290 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 289 ||
+        e.graph->ases->find(6)->second->all_anns->find(p)->second.priority != 189 ||
+        e.graph->ases->find(1)->second->all_anns->find(p)->second.priority != 288 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 188) {
+        std::cerr << "Propagted priority calculation failed." << std::endl;
+        return false;
+    }
+    return true;
+}
+
 /** Test propagating up (no propagation from multihomed - mode 1) in the following test graph.
  *  Horizontal lines are peer relationships, vertical lines are customer-provider
  * 
@@ -224,7 +284,7 @@ bool test_propagate_up() {
  */
 bool test_propagate_up_multihomed_standard() {
     Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 1);
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(3, 2, AS_REL_PROVIDER);
@@ -276,7 +336,7 @@ bool test_propagate_up_multihomed_standard() {
  */
 bool test_propagate_up_multihomed_peer_mode() {
     Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2);
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(3, 2, AS_REL_PROVIDER);
@@ -316,7 +376,118 @@ bool test_propagate_up_multihomed_peer_mode() {
     return true;
 }
 
-/** Test propagating down in the following test graph.
+/** Test propagating down without multihomed support in the following test graph.
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Starting propagation at 2, 4 and 5 should see the announcement.
+ */
+bool test_propagate_down_no_multihomed() {
+    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0);
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+
+    e.graph->decide_ranks();
+    
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    ann.from_monitor = true;
+    ann.priority = 290;
+    e.graph->ases->find(2)->second->process_announcement(ann, true);
+    e.propagate_down();
+    
+    // Check all announcements are propagted
+    if (!(e.graph->ases->find(1)->second->all_anns->size() == 0 &&
+        e.graph->ases->find(2)->second->all_anns->size() == 1 &&
+        e.graph->ases->find(3)->second->all_anns->size() == 0 &&
+        e.graph->ases->find(4)->second->all_anns->size() == 1 &&
+        e.graph->ases->find(5)->second->all_anns->size() == 1 &&
+        e.graph->ases->find(6)->second->all_anns->size() == 0)) {
+        std::cerr << "test_propagate_down_no_multihomed failed... Not all ASes have refrence when they should.." << std::endl;
+        return false;
+    }
+    
+    if (e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 290 ||
+        e.graph->ases->find(4)->second->all_anns->find(p)->second.priority != 89 ||
+        e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 89) {
+        std::cerr << "Propagated priority calculation failed." << std::endl;
+        return false;
+    }
+    return true;
+}
+
+/** Test propagating down without multihomed support in the following test graph.
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Starting propagation at 1, everyone but 3 and 6 should see the announcement.
+ */
+bool test_propagate_down_no_multihomed2() {
+    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0);
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+
+    e.graph->decide_ranks();
+    
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    ann.from_monitor = true;
+    ann.priority = 290;
+    e.graph->ases->find(1)->second->process_announcement(ann, true);
+    e.propagate_down();
+    
+    // Check all announcements are propagted
+    if (!(e.graph->ases->find(1)->second->all_anns->size() == 1 &&
+        e.graph->ases->find(2)->second->all_anns->size() == 1 &&
+        e.graph->ases->find(3)->second->all_anns->size() == 0 &&
+        e.graph->ases->find(4)->second->all_anns->size() == 1 &&
+        e.graph->ases->find(5)->second->all_anns->size() == 1 &&
+        e.graph->ases->find(6)->second->all_anns->size() == 0)) {
+        
+        std::cerr << "test_propagate_down_no_multihomed2 failed... Not all ASes have refrence when they should.." << std::endl;
+        return false;
+    }
+
+    if (e.graph->ases->find(1)->second->all_anns->find(p)->second.priority != 290 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 89 ||
+        e.graph->ases->find(4)->second->all_anns->find(p)->second.priority != 88 ||
+        e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 88) {
+        std::cerr << "Propagated priority calculation failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** Test propagating down with automatic multihomed mode (default behaviour) in the following test graph.
  *  Horizontal lines are peer relationships, vertical lines are customer-provider
  * 
  *    1
@@ -356,19 +527,20 @@ bool test_propagate_down() {
         e.graph->ases->find(4)->second->all_anns->size() == 1 &&
         e.graph->ases->find(5)->second->all_anns->size() == 1 &&
         e.graph->ases->find(6)->second->all_anns->size() == 0)) {
+        std::cerr << "test_propagate_down failed... Not all ASes have refrence when they should.." << std::endl;
         return false;
     }
     
     if (e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 290 ||
         e.graph->ases->find(4)->second->all_anns->find(p)->second.priority != 89 ||
         e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 89) {
-        std::cerr << "Propagted priority calculation failed." << std::endl;
+        std::cerr << "Propagated priority calculation failed." << std::endl;
         return false;
     }
     return true;
 }
 
-/** Test propagating down in the following test graph.
+/** Test propagating down with automatic multihomed mode (default behaviour) in the following test graph.
  *  Horizontal lines are peer relationships, vertical lines are customer-provider
  * 
  *    1
@@ -377,7 +549,7 @@ bool test_propagate_down() {
  *   /|   
  *  4 5--6 
  *
- *  Starting propagation at 1, everyone should see the announcement.
+ *  Starting propagation at 1, everyone but 3 and 6 should see the announcement.
  */
 bool test_propagate_down2() {
     Extrapolator e = Extrapolator();
@@ -408,18 +580,17 @@ bool test_propagate_down2() {
         e.graph->ases->find(4)->second->all_anns->size() == 1 &&
         e.graph->ases->find(5)->second->all_anns->size() == 1 &&
         e.graph->ases->find(6)->second->all_anns->size() == 0)) {
-        
         std::cerr << "test_propagate_down2 failed... Not all ASes have refrence when they should.." << std::endl;
         return false;
     }
-
-    // if (e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 290 &&
-    //     e.graph->ases->find(4)->second->all_anns->find(p)->second.priority != 89 &&
-    //     e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 89) {
-    //     std::cerr << "Propagted priority calculation failed." << std::endl;
-    //     return false;
-    // }
-
+    
+    if (e.graph->ases->find(1)->second->all_anns->find(p)->second.priority != 290 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 89 ||
+        e.graph->ases->find(4)->second->all_anns->find(p)->second.priority != 88 ||
+        e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 88) {
+        std::cerr << "Propagated priority calculation failed." << std::endl;
+        return false;
+    }
     return true;
 }
 
@@ -436,7 +607,7 @@ bool test_propagate_down2() {
  */
 bool test_propagate_down_multihomed_standard() {
     Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 1);
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(3, 2, AS_REL_PROVIDER);
@@ -478,7 +649,162 @@ bool test_propagate_down_multihomed_standard() {
     return true;
 }
 
-/** Test send_all_announcements in the following test graph.
+/** Test send_all_announcements with automatic multihomed mode (default behaviour) in the following test graph.
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *  1
+ *  |
+ *  2 3
+ *   \|
+ *    4
+ *
+ *  Sending announcements from 4, everyone but 1 should see the announcement.
+ */
+bool test_send_all_announcements() {
+    Extrapolator e = Extrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 3, AS_REL_PROVIDER);
+    e.graph->add_relationship(3, 4, AS_REL_CUSTOMER);
+
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(4);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p);
+    delete as_path;
+
+    // Check to providers
+    e.send_all_announcements(4, true, false, false);
+    if (!(e.graph->ases->find(1)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(2)->second->incoming_announcements->size() == 1 &&
+          e.graph->ases->find(3)->second->incoming_announcements->size() == 1 &&
+          e.graph->ases->find(4)->second->all_anns->size() == 1)) {
+        std::cerr << "Err sending to providers" << std::endl;
+        return false;
+    }
+    
+    // Check to peers
+    e.send_all_announcements(4, false, true, false);
+    if (!(e.graph->ases->find(1)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(2)->second->incoming_announcements->size() == 1 &&
+          e.graph->ases->find(3)->second->incoming_announcements->size() == 1 &&
+          e.graph->ases->find(4)->second->all_anns->size() == 1)) {
+        std::cerr << "Err sending to peers" << std::endl;
+        return false;
+    }
+
+    // Check to customers
+    e.send_all_announcements(4, false, false, true);
+    if (!(e.graph->ases->find(1)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(2)->second->incoming_announcements->size() == 1 &&
+          e.graph->ases->find(3)->second->incoming_announcements->size() == 1 &&
+          e.graph->ases->find(4)->second->all_anns->size() == 1)) {
+        std::cerr << "Err sending to customers" << std::endl;
+        return false;
+    }
+
+    // Process announcements to get the correct announcement priority
+    e.graph->ases->find(2)->second->process_announcements(true);
+    e.graph->ases->find(3)->second->process_announcements(true);
+    e.graph->ases->find(4)->second->process_announcements(true);
+
+    // Check priority calculation
+    if (e.graph->ases->find(4)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 299) {
+        std::cerr << "Send all announcement priority calculation failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** Test send_all_announcements with automatic multihomed mode (default behaviour) in the following test graph.
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *  1
+ *  |
+ *  2 3
+ *   \|
+ *    4
+ *
+ *  Sending announcements from 4 with existing announcements at 2 and 3 (same prefix as 4 and origin asn = 4), no one should see the announcement.
+ */
+bool test_send_all_announcements2() {
+    Extrapolator e = Extrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 3, AS_REL_PROVIDER);
+    e.graph->add_relationship(3, 4, AS_REL_CUSTOMER);
+
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(2);
+    as_path->push_back(4);
+    std::vector<uint32_t> *as_path2 = new std::vector<uint32_t>();
+    as_path2->push_back(3);
+    as_path2->push_back(4);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p);
+    e.give_ann_to_as_path(as_path2, p);
+    delete as_path;
+    delete as_path2;
+
+    // Check to providers
+    e.send_all_announcements(4, true, false, false);
+
+    if (!(e.graph->ases->find(1)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(2)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(3)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(4)->second->all_anns->size() == 1)) {
+        std::cerr << "Err sending to providers" << std::endl;
+        return false;
+    }
+    
+    // Check to peers
+    e.send_all_announcements(4, false, true, false);
+    if (!(e.graph->ases->find(1)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(2)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(3)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(4)->second->all_anns->size() == 1)) {
+        std::cerr << "Err sending to peers" << std::endl;
+        return false;
+    }
+
+    // Check to customers
+    e.send_all_announcements(4, false, false, true);
+    if (!(e.graph->ases->find(1)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(2)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(3)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(4)->second->all_anns->size() == 1)) {
+        std::cerr << "Err sending to customers" << std::endl;
+        return false;
+    }
+
+    // Process announcements to get the correct announcement priority
+    e.graph->ases->find(2)->second->process_announcements(true);
+    e.graph->ases->find(3)->second->process_announcements(true);
+    e.graph->ases->find(4)->second->process_announcements(true);
+
+    // Check priority calculation
+    if (e.graph->ases->find(4)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 299) {
+        std::cerr << "Send all announcement priority calculation failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** Test send_all_announcements without multihomed support in the following test graph.
  *  Horizontal lines are peer relationships, vertical lines are customer-provider
  * 
  *    1
@@ -489,8 +815,9 @@ bool test_propagate_down_multihomed_standard() {
  *
  *  Starting propagation at 2, only 6 and 7 should not see the announcement.
  */
-bool test_send_all_announcements() {
-    Extrapolator e = Extrapolator();
+bool test_send_all_announcements_no_multihomed() {
+    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -583,7 +910,7 @@ bool test_send_all_announcements() {
  */
 bool test_send_all_announcements_multihomed_standard1() {
     Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 1);
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -677,7 +1004,7 @@ bool test_send_all_announcements_multihomed_standard1() {
  */
 bool test_send_all_announcements_multihomed_standard2() {
     Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 1);
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -761,7 +1088,7 @@ bool test_send_all_announcements_multihomed_standard2() {
  */
 bool test_send_all_announcements_multihomed_peer_mode1() {
     Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2);
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -854,7 +1181,7 @@ bool test_send_all_announcements_multihomed_peer_mode1() {
  */
 bool test_send_all_announcements_multihomed_peer_mode2() {
     Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2);
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);

--- a/src/Tests/ExtrapolatorTest.cpp
+++ b/src/Tests/ExtrapolatorTest.cpp
@@ -804,6 +804,81 @@ bool test_send_all_announcements2() {
     return true;
 }
 
+/** Test send_all_announcements with automatic multihomed mode (default behaviour) in the following test graph.
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *  1
+ *  |
+ *  2 3
+ *   \|
+ *    4
+ *
+ *  Sending announcements from 4 with existing announcements at 2 (same prefix as 4 and origin asn = 4), no one should see the announcement.
+ */
+bool test_send_all_announcements3() {
+    Extrapolator e = Extrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 3, AS_REL_PROVIDER);
+    e.graph->add_relationship(3, 4, AS_REL_CUSTOMER);
+
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(2);
+    as_path->push_back(4);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p);
+    delete as_path;
+
+    // Check to providers
+    e.send_all_announcements(4, true, false, false);
+
+    if (!(e.graph->ases->find(1)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(2)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(3)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(4)->second->all_anns->size() == 1)) {
+        std::cerr << "Err sending to providers" << std::endl;
+        return false;
+    }
+    
+    // Check to peers
+    e.send_all_announcements(4, false, true, false);
+    if (!(e.graph->ases->find(1)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(2)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(3)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(4)->second->all_anns->size() == 1)) {
+        std::cerr << "Err sending to peers" << std::endl;
+        return false;
+    }
+
+    // Check to customers
+    e.send_all_announcements(4, false, false, true);
+    if (!(e.graph->ases->find(1)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(2)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(3)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(4)->second->all_anns->size() == 1)) {
+        std::cerr << "Err sending to customers" << std::endl;
+        return false;
+    }
+
+    // Process announcements to get the correct announcement priority
+    e.graph->ases->find(2)->second->process_announcements(true);
+    e.graph->ases->find(3)->second->process_announcements(true);
+    e.graph->ases->find(4)->second->process_announcements(true);
+
+    // Check priority calculation
+    if (e.graph->ases->find(4)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299) {
+        std::cerr << "Send all announcement priority calculation failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
 /** Test send_all_announcements without multihomed support in the following test graph.
  *  Horizontal lines are peer relationships, vertical lines are customer-provider
  * 

--- a/src/Tests/Tests.cpp
+++ b/src/Tests/Tests.cpp
@@ -114,6 +114,9 @@ BOOST_AUTO_TEST_CASE( Extrapolator_constructor ) {
 BOOST_AUTO_TEST_CASE( Extrapolator_give_ann_to_as_path ) {
         BOOST_CHECK( test_give_ann_to_as_path() );
 }
+BOOST_AUTO_TEST_CASE( Extrapolator_propagate_up_no_multihomed ) {
+        BOOST_CHECK( test_propagate_up_no_multihomed() );
+}
 BOOST_AUTO_TEST_CASE( Extrapolator_propagate_up ) {
         BOOST_CHECK( test_propagate_up() );
 }
@@ -122,6 +125,12 @@ BOOST_AUTO_TEST_CASE( Extrapolator_propagate_up_multihomed_standard ) {
 }
 BOOST_AUTO_TEST_CASE( Extrapolator_propagate_up_multihomed_peer_mode ) {
         BOOST_CHECK( test_propagate_up_multihomed_peer_mode() );
+}
+BOOST_AUTO_TEST_CASE( Extrapolator_propagate_down_no_multihomed ) {
+        BOOST_CHECK( test_propagate_down_no_multihomed() );
+}
+BOOST_AUTO_TEST_CASE( Extrapolator_propagate_down_no_multihomed2 ) {
+        BOOST_CHECK( test_propagate_down_no_multihomed2() );
 }
 BOOST_AUTO_TEST_CASE( Extrapolator_propagate_down ) {
         BOOST_CHECK( test_propagate_down() );
@@ -137,6 +146,12 @@ BOOST_AUTO_TEST_CASE( Extrapolator_save_results_parallel ) {
 }
 BOOST_AUTO_TEST_CASE( Extrapolator_send_all_announcements ) {
         BOOST_CHECK( test_send_all_announcements() );
+}
+BOOST_AUTO_TEST_CASE( Extrapolator_send_all_announcements2 ) {
+        BOOST_CHECK( test_send_all_announcements2() );
+}
+BOOST_AUTO_TEST_CASE( Extrapolator_send_all_announcements_no_multihomed ) {
+        BOOST_CHECK( test_send_all_announcements_no_multihomed() );
 }
 BOOST_AUTO_TEST_CASE( Extrapolator_send_all_announcements_multihomed_standard1 ) {
         BOOST_CHECK( test_send_all_announcements_multihomed_standard1() );

--- a/src/Tests/Tests.cpp
+++ b/src/Tests/Tests.cpp
@@ -150,6 +150,9 @@ BOOST_AUTO_TEST_CASE( Extrapolator_send_all_announcements ) {
 BOOST_AUTO_TEST_CASE( Extrapolator_send_all_announcements2 ) {
         BOOST_CHECK( test_send_all_announcements2() );
 }
+BOOST_AUTO_TEST_CASE( Extrapolator_send_all_announcements3 ) {
+        BOOST_CHECK( test_send_all_announcements3() );
+}
 BOOST_AUTO_TEST_CASE( Extrapolator_send_all_announcements_no_multihomed ) {
         BOOST_CHECK( test_send_all_announcements_no_multihomed() );
 }


### PR DESCRIPTION
Now, by default, when an AS in multihomed, the extrapolator propagates its announcement to providers if there are some that haven't received an announcement from that prefix with origin = current multihomed AS. Multihomed ASes also propagate to peers in that mode. I also created tests for the new mode.