### PR TITLE
Use Logger instead of cout and cerr

### DIFF
--- a/include/Prefix.h
+++ b/include/Prefix.h
@@ -29,6 +29,8 @@
 #include <string>
 #include <iostream>
 
+#include "Logger.h"
+
 
 // Use uint32_t for IPv4, unsigned __int128 for IPv6
 template <typename Integer = uint32_t>
@@ -131,7 +133,7 @@ public:
         // Default errors to 0.0.0.0
         if (error_f == true) {
             ipv4_ip_int = 0;
-            std::cerr << "Caught malformed IPv4 address: " << addr_str << std::endl;
+            BOOST_LOG_TRIVIAL(error) << "Caught malformed IPv4 address: " << addr_str;
         }
         return ipv4_ip_int;
     }
@@ -202,7 +204,7 @@ public:
         // Default errors to /0
         if (error_f == true) {
             ipv4_mask_int = 0;
-            std::cerr << "Caught malformed IPv4 subnet mask: " << mask_str << std::endl;
+            BOOST_LOG_TRIVIAL(error) << "Caught malformed IPv4 subnet mask: " << mask_str;
         }
         return ipv4_mask_int;
     }

--- a/main.cpp
+++ b/main.cpp
@@ -48,7 +48,7 @@
 
 void intro() {
     // This needs to be finished
-    BOOST_LOG_TRIVIAL(info) << "***** Routing Extrapolator v0.3 *****" << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "***** Routing Extrapolator v0.3 *****";
     BOOST_LOG_TRIVIAL(info) << "This is free software: you are free to change and redistribute it.";
     BOOST_LOG_TRIVIAL(info) << "There is NO WARRANTY, to the extent permitted by law.";
 }

--- a/main.cpp
+++ b/main.cpp
@@ -27,8 +27,6 @@
 #include <thread>
 #include <semaphore.h>
 
-#include "Logger.h"
-
 #include "ASes/AS.h"
 #include "Graphs/ASGraph.h"
 #include "Announcements/Announcement.h"
@@ -50,9 +48,9 @@
 
 void intro() {
     // This needs to be finished
-    std::cout << "***** Routing Extrapolator v0.3 *****" << std::endl;
-    std::cout << "This is free software: you are free to change and redistribute it." << std::endl;
-    std::cout << "There is NO WARRANTY, to the extent permitted by law." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "***** Routing Extrapolator v0.3 *****" << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "This is free software: you are free to change and redistribute it.";
+    BOOST_LOG_TRIVIAL(info) << "There is NO WARRANTY, to the extent permitted by law.";
 }
 
 int main(int argc, char *argv[]) {

--- a/src/Extrapolators/BaseExtrapolator.cpp
+++ b/src/Extrapolators/BaseExtrapolator.cpp
@@ -60,7 +60,7 @@ std::vector<uint32_t>* BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementT
         try {
             as_path->push_back(std::stoul(token));
         } catch(...) {
-            std::cerr << "Parse path error, token was: " << token << std::endl;
+            BOOST_LOG_TRIVIAL(error) << "Parse path error, token was: " << token;
         }
         path_as_string.erase(0,pos + delimiter.length());
     }
@@ -68,7 +68,7 @@ std::vector<uint32_t>* BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementT
     try {
         as_path->push_back(std::stoul(path_as_string));
     } catch(...) {
-        std::cerr << "Parse path error, token was: " << path_as_string << std::endl;
+        BOOST_LOG_TRIVIAL(error) << "Parse path error, token was: " << path_as_string;
     }
     return as_path;
 }
@@ -195,12 +195,12 @@ void BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::save
 template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
 void BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::save_results(int iteration){
     if (store_invert_results) {
-        std::cout << "Saving Inverse Results From Iteration: " << iteration << std::endl;
+        BOOST_LOG_TRIVIAL(info) << "Saving Inverse Results From Iteration: " << iteration;
     } else {
-        std::cout << "Saving Results From Iteration: " << iteration << std::endl;
+        BOOST_LOG_TRIVIAL(info) << "Saving Results From Iteration: " << iteration;
     }
     if (store_depref_results) {
-        std::cout << "Saving Depref Results From Iteration: " << iteration << std::endl;
+        BOOST_LOG_TRIVIAL(info) << "Saving Depref Results From Iteration: " << iteration;
     }
     std::vector<std::thread> threads;
     int cpus = std::thread::hardware_concurrency();

--- a/src/Extrapolators/BlockedExtrapolator.cpp
+++ b/src/Extrapolators/BlockedExtrapolator.cpp
@@ -44,7 +44,7 @@ template <class SQLQuerierType, class GraphType, class AnnouncementType, class A
 void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::perform_propagation() {
     init();
 
-    std::cout << "Generating subnet blocks..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Generating subnet blocks...";
     
     // Generate iteration blocks
     std::vector<Prefix<>*> *prefix_blocks = new std::vector<Prefix<>*>; // Prefix blocks
@@ -62,7 +62,7 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::p
 
 template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
 void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::extrapolate(std::vector<Prefix<>*> *prefix_blocks, std::vector<Prefix<>*> *subnet_blocks) {
-    std::cout << "Beginning propagation..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Beginning propagation...";
     
     // Seed MRT announcements and propagate
     uint32_t announcement_count = 0; 
@@ -77,8 +77,8 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::e
 
     auto ext_finish = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> e = ext_finish - ext_start;
-    std::cout << "Block elapsed time: " << e.count() << std::endl;
-    std::cout << "Announcement count: " << announcement_count << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Block elapsed time: " << e.count();
+    BOOST_LOG_TRIVIAL(info) << "Announcement count: " << announcement_count;
 }
 
 template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
@@ -145,7 +145,7 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::e
                                                                                                     std::vector<Prefix<>*> *prefix_set) {
     // For each unprocessed block of announcements 
     for (Prefix<>* prefix : *prefix_set) {
-        std::cout << "Selecting Announcements..." << std::endl;
+        BOOST_LOG_TRIVIAL(info) << "Selecting Announcements...";
         auto prefix_start = std::chrono::high_resolution_clock::now();
         
         // Handle prefix blocks or subnet blocks of announcements
@@ -164,7 +164,7 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::e
             break;
         announcement_count += bsize;
         
-        std::cout << "Seeding announcements..." << std::endl;
+        BOOST_LOG_TRIVIAL(info) << "Seeding announcements...";
         // For all announcements in this block
         for (pqxx::result::size_type i = 0; i < bsize; i++) {
             // Get row origin
@@ -215,14 +215,14 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::e
             delete as_path;
         }
         // Propagate for this subnet
-        std::cout << "Propagating..." << std::endl;
+        BOOST_LOG_TRIVIAL(info) << "Propagating...";
         this->propagate_up();
         this->propagate_down();
         this->save_results(iteration);
         this->graph->clear_announcements();
         iteration++;
         
-        std::cout << prefix->to_cidr() << " completed." << std::endl;
+        BOOST_LOG_TRIVIAL(info) << prefix->to_cidr() << " completed.";
         auto prefix_finish = std::chrono::high_resolution_clock::now();
         std::chrono::duration<double> q = prefix_finish - prefix_start;
     }

--- a/src/Extrapolators/EZExtrapolator.cpp
+++ b/src/Extrapolators/EZExtrapolator.cpp
@@ -46,7 +46,7 @@ void EZExtrapolator::init() {
 void EZExtrapolator::perform_propagation() {
     init();
 
-    std::cout << "Generating subnet blocks..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Generating subnet blocks...";
     
     // Generate iteration blocks
     std::vector<Prefix<>*> *prefix_blocks = new std::vector<Prefix<>*>; // Prefix blocks
@@ -69,7 +69,7 @@ void EZExtrapolator::perform_propagation() {
         successful_connections = 0;
         disconnections = 0;
 
-        std::cout << "Round #" << round << std::endl;
+        BOOST_LOG_TRIVIAL(info) << "Round #" << round;
 
         extrapolate(prefix_blocks, subnet_blocks);
 
@@ -113,7 +113,7 @@ void EZExtrapolator::perform_propagation() {
             //Re calculate the components with these new relationships
             graph->process(querier);
         } else {
-            std::cout << "Round #" << round << ": No more attacks" << std::endl;
+            BOOST_LOG_TRIVIAL(info) << "Round #" << round << ": No more attacks";
         }
     } while(successful_attacks > 0 && round <= num_rounds - 1);
     

--- a/src/Extrapolators/ROVppExtrapolator.cpp
+++ b/src/Extrapolators/ROVppExtrapolator.cpp
@@ -69,7 +69,7 @@ void ROVppExtrapolator::perform_propagation(bool propagate_twice=true) {
     graph->create_graph_from_db(querier);
     
     // Main differences start here
-    std::cout << "Beginning propagation..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Beginning propagation...";
     
     // Seed MRT announcements and propagate    
     // Iterate over Victim table (first), then Attacker table (second)
@@ -112,10 +112,10 @@ void ROVppExtrapolator::perform_propagation(bool propagate_twice=true) {
         propagate_down();
         count++;
         if (count >= 100) {
-            std::cout << "Exceeded max propagation cycles" << std::endl;
+            BOOST_LOG_TRIVIAL(info) << "Exceeded max propagation cycles";
         }
     } while (ROVppAS::graph_changed && count < 100);
-    std::cout << "Times propagated: " << count << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Times propagated: " << count;
     
     // std::ofstream gvpythonfile;
     // gvpythonfile.open("asgraph.py");
@@ -123,7 +123,7 @@ void ROVppExtrapolator::perform_propagation(bool propagate_twice=true) {
     // rovpp_graph->to_graphviz(gvpythonfile, to_graph);
     // gvpythonfile.close();
     save_results(iter);
-    std::cout << "completed: ";
+    BOOST_LOG_TRIVIAL(info) << "completed: ";
 }
 
 void ROVppExtrapolator::give_ann_to_as_path(std::vector<uint32_t>* as_path, 
@@ -578,7 +578,7 @@ void ROVppExtrapolator::send_all_announcements(uint32_t asn,
 }
 
 bool ROVppExtrapolator::loop_check(Prefix<> p, const ROVppAS& cur_as, uint32_t a, int d) {
-    if (d > 100) { std::cerr << "Maximum depth exceeded during traceback.\n"; return true; }
+    if (d > 100) { BOOST_LOG_TRIVIAL(error) << "Maximum depth exceeded during traceback.\n"; return true; }
     auto ann_pair = cur_as.loc_rib->find(p);
     const Announcement &ann = ann_pair->second;
     // i wonder if a cabinet holding a subwoofer counts as a bass case
@@ -593,7 +593,7 @@ bool ROVppExtrapolator::loop_check(Prefix<> p, const ROVppAS& cur_as, uint32_t a
         return false; 
     }
     auto next_as_pair = graph->ases->find(ann.received_from_asn);
-    if (next_as_pair == graph->ases->end()) { std::cerr << "Traced back announcement to nonexistent AS.\n"; return true; }
+    if (next_as_pair == graph->ases->end()) { BOOST_LOG_TRIVIAL(error) << "Traced back announcement to nonexistent AS.\n"; return true; }
     const ROVppAS& next_as = *next_as_pair->second;
     return loop_check(p, next_as, a, d+1);
 }
@@ -608,7 +608,7 @@ void ROVppExtrapolator::save_results(int iteration) {
     blackhole_outfile.open(blackhole_file_name);
     
     // Iterate over all nodes in graph
-    std::cout << "Saving Results From Iteration: " << iteration << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Saving Results From Iteration: " << iteration;
     for (auto &as : *graph->ases){
         as.second->stream_announcements(outfile);
         // Check if it's a ROVpp node

--- a/src/Extrapolators/ROVppExtrapolator.cpp
+++ b/src/Extrapolators/ROVppExtrapolator.cpp
@@ -578,7 +578,7 @@ void ROVppExtrapolator::send_all_announcements(uint32_t asn,
 }
 
 bool ROVppExtrapolator::loop_check(Prefix<> p, const ROVppAS& cur_as, uint32_t a, int d) {
-    if (d > 100) { BOOST_LOG_TRIVIAL(error) << "Maximum depth exceeded during traceback.\n"; return true; }
+    if (d > 100) { BOOST_LOG_TRIVIAL(error) << "Maximum depth exceeded during traceback."; return true; }
     auto ann_pair = cur_as.loc_rib->find(p);
     const Announcement &ann = ann_pair->second;
     // i wonder if a cabinet holding a subwoofer counts as a bass case
@@ -593,7 +593,7 @@ bool ROVppExtrapolator::loop_check(Prefix<> p, const ROVppAS& cur_as, uint32_t a
         return false; 
     }
     auto next_as_pair = graph->ases->find(ann.received_from_asn);
-    if (next_as_pair == graph->ases->end()) { BOOST_LOG_TRIVIAL(error) << "Traced back announcement to nonexistent AS.\n"; return true; }
+    if (next_as_pair == graph->ases->end()) { BOOST_LOG_TRIVIAL(error) << "Traced back announcement to nonexistent AS."; return true; }
     const ROVppAS& next_as = *next_as_pair->second;
     return loop_check(p, next_as, a, d+1);
 }

--- a/src/Graphs/BaseGraph.cpp
+++ b/src/Graphs/BaseGraph.cpp
@@ -170,7 +170,7 @@ void BaseGraph<ASType>::save_stubs_to_db(SQLQuerier *querier) {
         closedir(dir);
 
     std::ofstream outfile;
-    std::cout << "Saving Stubs..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Saving Stubs...";
     std::string file_name = "/dev/shm/bgp/stubs.csv";
     outfile.open(file_name);
 
@@ -191,7 +191,7 @@ void BaseGraph<ASType>::save_non_stubs_to_db(SQLQuerier *querier) {
         closedir(dir);
 
     std::ofstream outfile;
-    std::cout << "Saving Non-Stubs..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Saving Non-Stubs...";
     std::string file_name = "/dev/shm/bgp/non-stubs.csv";
     outfile.open(file_name);
 
@@ -212,7 +212,7 @@ void BaseGraph<ASType>::save_supernodes_to_db(SQLQuerier *querier) {
         closedir(dir);
 
     std::ofstream outfile;
-    std::cout << "Saving Supernodes..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Saving Supernodes...";
     std::string file_name = "/dev/shm/bgp/supernodes.csv";
     outfile.open(file_name); 
     
@@ -430,7 +430,7 @@ void BaseGraph<ASType>::combine_components() {
 template <class ASType>
 void BaseGraph<ASType>::printDebug() {
     for (auto const& as : *ases)
-        std::cout << as.first << ':' << as.second->asn << std::endl;
+        BOOST_LOG_TRIVIAL(debug) << as.first << ':' << as.second->asn;
     return; 
 }
 

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -16,7 +16,7 @@ void Logger::init_logger(bool std_out, std::string folder, unsigned int severity
     }
 
     if(std_out)
-        boost::log::add_console_log(std::cout, boost::log::keywords::format = log_format);
+        boost::log::add_console_log(std::cout, boost::log::keywords::format = log_format, boost::log::keywords::auto_flush = true);
 
     if(folder != "") {
         boost::log::add_file_log (

--- a/src/SQLQueriers/ROVppSQLQuerier.cpp
+++ b/src/SQLQueriers/ROVppSQLQuerier.cpp
@@ -116,7 +116,7 @@ void ROVppSQLQuerier::create_results_tbl(){
     std::string sql = std::string("CREATE UNLOGGED TABLE IF NOT EXISTS " + results_table + " (\
     asn bigint,prefix cidr, origin bigint, received_from_asn \
     bigint, time bigint, alternate_as bigint, opt_flag int); GRANT ALL ON TABLE " + results_table + " TO bgp_user;");
-    std::cout << "Creating " << results_table << " table..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Creating " << results_table << " table...";
     execute(sql, false);
 }
 
@@ -138,10 +138,10 @@ void ROVppSQLQuerier::copy_blackhole_list_to_db(std::string file_name) {
 void ROVppSQLQuerier::create_rovpp_blacklist_tbl() {
   // Drop the results table
   std::string sql = std::string("DROP TABLE IF EXISTS " ROVPP_BLACKHOLES_TABLE " ;");
-  std::cout << "Dropping " ROVPP_BLACKHOLES_TABLE " table..." << std::endl;
+  BOOST_LOG_TRIVIAL(info) << "Dropping " ROVPP_BLACKHOLES_TABLE " table...";
   execute(sql, false);
   // Create it again
   std::string sql2 = std::string("CREATE TABLE IF NOT EXISTS " ROVPP_BLACKHOLES_TABLE "(asn BIGINT, prefix CIDR, origin BIGINT, received_from_asn BIGINT, tstamp BIGINT)");
-  std::cout << "Creating " ROVPP_BLACKHOLES_TABLE " table..." << std::endl;
+  BOOST_LOG_TRIVIAL(info) << "Creating " ROVPP_BLACKHOLES_TABLE " table...";
   execute(sql2, false);
 }

--- a/src/SQLQueriers/SQLQuerier.cpp
+++ b/src/SQLQueriers/SQLQuerier.cpp
@@ -62,7 +62,7 @@ SQLQuerier::~SQLQuerier() {
 void SQLQuerier::read_config() {
     using namespace std;
 
-    cout << "Config section: " << config_section << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Config section: " << config_section;
     
     program_options::variables_map var_map;
 
@@ -107,7 +107,7 @@ void SQLQuerier::read_config() {
             port = var_map[config_section + ".port"].as<string>();
         }
     } else {
-        std::cerr << "Error loading config file \"" << config_path << "\"" << std::endl;
+        BOOST_LOG_TRIVIAL(error) << "Error loading config file \"" << config_path << "\"";
     }
 }
 
@@ -127,11 +127,11 @@ void SQLQuerier::open_connection() {
         if (conn->is_open()) {
             C = conn;
         } else {
-            std::cerr << "Failed to connect to database : " << db_name <<std::endl;
+            BOOST_LOG_TRIVIAL(error) << "Failed to connect to database : " << db_name;
             return;
         }
     } catch (const std::exception &e) {
-        std::cerr << e.what() << std::endl;
+        BOOST_LOG_TRIVIAL(error) << e.what();
     }
 }
 
@@ -159,7 +159,7 @@ pqxx::result SQLQuerier::execute(std::string sql, bool insert) {
             txn.commit();
             return R;
         } catch(const std::exception &e) {
-            std::cerr << e.what() <<std::endl;
+            BOOST_LOG_TRIVIAL(error) << e.what();
         }
     } else {
         try {
@@ -167,7 +167,7 @@ pqxx::result SQLQuerier::execute(std::string sql, bool insert) {
             pqxx::result R( N.exec(sql));
             return R;
         } catch(const std::exception &e) {
-            std::cerr << e.what() <<std::endl;
+            BOOST_LOG_TRIVIAL(error) << e.what();
         }
     }
     return R;
@@ -289,7 +289,7 @@ void SQLQuerier::clear_supernodes_from_db() {
  */
 void SQLQuerier::create_stubs_tbl() {
     std::string sql = std::string("CREATE TABLE IF NOT EXISTS " STUBS_TABLE " (stub_asn BIGSERIAL PRIMARY KEY,parent_asn bigint);");
-    std::cout << "Creating stubs table..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Creating stubs table...";
     execute(sql, false);
 }
 
@@ -298,7 +298,7 @@ void SQLQuerier::create_stubs_tbl() {
  */
 void SQLQuerier::create_non_stubs_tbl() {
     std::string sql = std::string("CREATE TABLE IF NOT EXISTS " NON_STUBS_TABLE " (non_stub_asn BIGSERIAL PRIMARY KEY);");
-    std::cout << "Creating non_stubs table..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Creating non_stubs table...";
     execute(sql, false);
 }
 
@@ -307,7 +307,7 @@ void SQLQuerier::create_non_stubs_tbl() {
  */
 void SQLQuerier::create_supernodes_tbl() {
     std::string sql = std::string("CREATE TABLE IF NOT EXISTS " SUPERNODES_TABLE "(supernode_asn BIGSERIAL PRIMARY KEY, supernode_lowest_asn bigint)");
-    std::cout << "Creating supernodes table..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Creating supernodes table...";
     execute(sql, false);
 }
 
@@ -372,7 +372,7 @@ void SQLQuerier::create_results_tbl() {
     std::string sql = std::string("CREATE UNLOGGED TABLE IF NOT EXISTS " + results_table + " (\
     asn bigint,prefix cidr, origin bigint, received_from_asn \
     bigint, time bigint); GRANT ALL ON TABLE " + results_table + " TO bgp_user;");
-    std::cout << "Creating results table..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Creating results table...";
     execute(sql, false);
 }
 
@@ -383,7 +383,7 @@ void SQLQuerier::create_depref_tbl() {
     std::string sql = std::string("CREATE UNLOGGED TABLE IF NOT EXISTS " + depref_table + " (\
     asn bigint,prefix cidr, origin bigint, received_from_asn \
     bigint, time bigint); GRANT ALL ON TABLE " + depref_table + " TO bgp_user;");
-    std::cout << "Creating depref table..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Creating depref table...";
     execute(sql, false);
 }
 
@@ -396,7 +396,7 @@ void SQLQuerier::create_inverse_results_tbl() {
     "(asn bigint,prefix cidr, origin bigint) ";
     sql += ";";
     sql += "GRANT ALL ON TABLE " + inverse_results_table + " TO bgp_user;";
-    std::cout << "Creating inverse results table..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Creating inverse results table...";
     execute(sql, false);
 }
 
@@ -433,6 +433,6 @@ void SQLQuerier::copy_inverse_results_to_db(std::string file_name) {
 void SQLQuerier::create_results_index() {
     // Version of postgres must support this
     std::string sql = std::string("CREATE INDEX ON " + results_table + " USING GIST(prefix inet_ops, origin)");
-    std::cout << "Generating index on results..." << std::endl;
+    BOOST_LOG_TRIVIAL(info) << "Generating index on results...";
     execute(sql, false);
 }


### PR DESCRIPTION
Changed the code to use Logger instead of `cout` and `cerr`. Tests still use normal console output instead of Logger.
Added `boost::log::keywords::auto_flush = true` argument to `boost::log::add_console_log()` in Logger.cpp. That way it flushes the buffers after each log record is written