### PR TITLE
Refactor parse_path and add a test

### DIFF
--- a/include/Tests/Tests.h
+++ b/include/Tests/Tests.h
@@ -87,6 +87,7 @@ bool test_combine_components();
 
 // Prototypes for ExtrapolatorTest.cpp
 bool test_Extrapolator_constructor();
+bool test_parse_path();
 bool test_propagate_up_no_multihomed();
 bool test_propagate_up();
 bool test_propagate_up_multihomed_standard();

--- a/src/Extrapolators/BaseExtrapolator.cpp
+++ b/src/Extrapolators/BaseExtrapolator.cpp
@@ -55,7 +55,11 @@ std::vector<uint32_t>* BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementT
     std::stringstream str_stream(path_as_string);
     std::string tokenN;
     while(getline(str_stream, tokenN, ',')) {
-        as_path->push_back(std::stoul(tokenN));
+        try {
+            as_path->push_back(std::stoul(tokenN));
+        } catch(...) {
+            BOOST_LOG_TRIVIAL(error) << "Parse path error, token was: " << tokenN;
+        }
     }
     return as_path;
 }

--- a/src/Extrapolators/BaseExtrapolator.cpp
+++ b/src/Extrapolators/BaseExtrapolator.cpp
@@ -52,23 +52,10 @@ std::vector<uint32_t>* BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementT
     path_as_string.erase(std::find(path_as_string.begin(), path_as_string.end(), '{'));
 
     // Fill as_path vector from parsing string
-    std::string delimiter = ",";
-    std::string::size_type pos = 0;
-    std::string token;
-    while ((pos = path_as_string.find(delimiter)) != std::string::npos) {
-        token = path_as_string.substr(0,pos);
-        try {
-            as_path->push_back(std::stoul(token));
-        } catch(...) {
-            BOOST_LOG_TRIVIAL(error) << "Parse path error, token was: " << token;
-        }
-        path_as_string.erase(0,pos + delimiter.length());
-    }
-    // Handle last ASN after loop
-    try {
-        as_path->push_back(std::stoul(path_as_string));
-    } catch(...) {
-        BOOST_LOG_TRIVIAL(error) << "Parse path error, token was: " << path_as_string;
+    std::stringstream str_stream(path_as_string);
+    std::string tokenN;
+    while(getline(str_stream, tokenN, ',')) {
+        as_path->push_back(std::stoul(tokenN));
     }
     return as_path;
 }

--- a/src/Tests/ExtrapolatorTest.cpp
+++ b/src/Tests/ExtrapolatorTest.cpp
@@ -70,6 +70,28 @@ bool test_find_loop() {
     return true;
 }
 
+// Test parse_path function
+bool test_parse_path() {
+    Extrapolator e = Extrapolator();
+    std::vector<uint32_t> *as_path = e.parse_path("{63027,32899,12083,1299,14522}");
+    std::vector<uint32_t> true_as_path {63027,32899,12083,1299,14522};
+
+    if (as_path->size() != true_as_path.size()) {
+        std::cerr << "Parse path failed." << std::endl;
+        return false;
+    }
+
+    // Check that every AS in as_path is correct
+    for (unsigned int i = 0; i < as_path->size(); i++) {
+        if (as_path->at(i) != true_as_path.at(i)) {
+            std::cerr << "Parse path failed." << std::endl;
+            return false;
+        }
+    }
+    
+    return true;
+}
+
 /** Test seeding the graph with announcements from monitors. 
  *  Horizontal lines are peer relationships, vertical lines are customer-provider
  * 

--- a/src/Tests/Tests.cpp
+++ b/src/Tests/Tests.cpp
@@ -111,6 +111,9 @@ BOOST_AUTO_TEST_CASE( ASGraph_combine_components_test ) {
 BOOST_AUTO_TEST_CASE( Extrapolator_constructor ) {
         BOOST_CHECK( test_Extrapolator_constructor() );
 }
+BOOST_AUTO_TEST_CASE( Extrapolator_parse_path ) {
+        BOOST_CHECK( test_parse_path() );
+}
 BOOST_AUTO_TEST_CASE( Extrapolator_give_ann_to_as_path ) {
         BOOST_CHECK( test_give_ann_to_as_path() );
 }


### PR DESCRIPTION
parse_path now uses a stringstream to simplify parsing of an as_path. There is also a test for this function.