### PR TITLE
Fix for Issue_ID 6

### DIFF
--- a/ROVppExtrapolator.cpp
+++ b/ROVppExtrapolator.cpp
@@ -225,7 +225,7 @@ void ROVppExtrapolator::give_ann_to_as_path(std::vector<uint32_t>* as_path,
         // If this AS is the origin
         if (it == as_path->rbegin()){
             // ROVpp: Set the recv_from to proper flag
-            if (roa_validity == ROA_INVALID_1 || roa_validity == ROA_INVALID_2 || roa_validity == ROA_INVALID_3) {
+            if (rovpp_graph->attackers->find(*it) != rovpp_graph->attackers->end()) {
                 received_from_asn = 64513;
             } else {
                 received_from_asn = 64514;


### PR DESCRIPTION
Issue_ID: 6
Location: ROVppExtrapolator::give_ann_to_as_path() Lines 226 - 233
Bug: In superprefix attacks (or other attacks where the attacker is
producing an announcement with an unknown roa_validity) the optimization
flag for NOTHIJACKED is applied to the superprefix (i.e. the unknown
roa_validity announcement). It should be given the HIJACKED optimization
flag instead (Right?)
Cause: There's a logical check for assigning the optimization flag that
applies it solely on the roa_validity value, when it should also
consider whether or not it's the attacker or not.
Expected Impact: Doesn’t affect results since the most specific prefix
will always be chosen, however, should be fixed for cases where the
hijack may have an unknown roa validity (which we currently do not have)
Discussed: yes

Much easier to fix than I thought. Now all system tests and Extrapolator unit tests pass. 