### PR TITLE
ROV reference policy

### DIFF
--- a/include/ASes/BaseAS.h
+++ b/include/ASes/BaseAS.h
@@ -42,6 +42,7 @@
 #include "Announcements/Announcement.h"
 #include "Announcements/EZAnnouncement.h"
 #include "Announcements/ROVppAnnouncement.h"
+#include "Announcements/ROVAnnouncement.h"
 
 template <class AnnouncementType>
 class BaseAS {

--- a/include/ASes/ROVAS.h
+++ b/include/ASes/ROVAS.h
@@ -1,0 +1,51 @@
+#ifndef ROV_AS_H
+#define ROV_AS_H
+
+#include "ASes/BaseAS.h"
+#include "Announcements/ROVAnnouncement.h"
+
+#define HIJACKED_ASN 64513
+#define NOTHIJACKED_ASN 64514
+#define ROVPPAS_TYPE_ROV 1 // Flag for the standard ROV policy
+
+class ROVAS : public BaseAS<ROVAnnouncement> {
+public:
+    ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers, bool store_depref_results, std::map<std::pair<Prefix<>, uint32_t>, std::set<uint32_t>*> *inverse_results);
+    ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers, bool store_depref_results);
+    ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers);
+    ROVAS();
+    ~ROVAS();
+
+    /** Processes a single ROVAnnouncement, adding it to the AS's set of announcements if appropriate
+     *
+     * Approximates BGP best path selection based on ROVAnnouncement priority
+     * Simulates ROV if this AS adopts it
+     * Called by ?process_announcements? and ROVExtrapolator.give_ann_to_as_path()
+     * 
+     * @param &ann the rovannouncement to be processed
+     * @param ran flag to enable random tiebreaks
+     */ 
+    virtual void process_announcement(ROVAnnouncement &ann, bool ran=true);
+
+    /** Checks whether an announcement was sent by an attacker
+     * @param &ann the annoucement to check
+     */
+    bool is_from_attacker(ROVAnnouncement &ann);
+    // Checks whether this AS is an attacker
+    bool is_attacker();
+
+    /** Sets ROV adoption of the AS
+     * @param adopts_rov true if adopts, false if doesn't
+     */
+    void set_rov_adoption(bool adopts_rov);
+    // Returns ROV adoption of the AS
+    bool get_rov_adoption();
+
+protected: 
+    // Set of all known attackers
+    std::set<uint32_t> *attackers;
+    // Variable that specifies if this AS adopts the ROV policy
+    bool adopts_rov;        
+};
+
+#endif

--- a/include/ASes/ROVAS.h
+++ b/include/ASes/ROVAS.h
@@ -13,6 +13,7 @@ public:
     ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers, bool store_depref_results, std::map<std::pair<Prefix<>, uint32_t>, std::set<uint32_t>*> *inverse_results);
     ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers, bool store_depref_results);
     ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers);
+    ROVAS(uint32_t asn);
     ROVAS();
     ~ROVAS();
 
@@ -41,7 +42,7 @@ public:
     // Returns ROV adoption of the AS
     bool get_rov_adoption();
 
-protected: 
+private: 
     // Set of all known attackers
     std::set<uint32_t> *attackers;
     // Variable that specifies if this AS adopts the ROV policy

--- a/include/ASes/ROVAS.h
+++ b/include/ASes/ROVAS.h
@@ -6,7 +6,7 @@
 
 #define HIJACKED_ASN 64513
 #define NOTHIJACKED_ASN 64514
-#define ROVPPAS_TYPE_ROV 1 // Flag for the standard ROV policy
+#define ROVPPAS_TYPE_ROV 2 // Flag for the standard ROV policy
 
 class ROVAS : public BaseAS<ROVAnnouncement> {
 public:
@@ -21,7 +21,7 @@ public:
      *
      * Approximates BGP best path selection based on ROVAnnouncement priority
      * Simulates ROV if this AS adopts it
-     * Called by ?process_announcements? and ROVExtrapolator.give_ann_to_as_path()
+     * Called by process_announcements and ROVExtrapolator.give_ann_to_as_path()
      * 
      * @param &ann the rovannouncement to be processed
      * @param ran flag to enable random tiebreaks

--- a/include/ASes/ROVppAS.h
+++ b/include/ASes/ROVppAS.h
@@ -38,7 +38,7 @@
 // They can be used to identify the type of ROVppAS
 // and the in the set_rovpp_as_type function to set the type.
 #define ROVPPAS_TYPE_BGP 0        // Regular BGP
-#define ROVPPAS_TYPE_ROV 1        // Just standard ROV
+#define ROVPPAS_TYPE_ROV 2        // Just standard ROV
 #define ROVPPAS_TYPE_ROVPP0 7      // ROVpp 0 (Just don't send to bad neighbors)
 #define ROVPPAS_TYPE_ROVPP 2      // ROVpp 0.1 (Just Blackholing)
 #define ROVPPAS_TYPE_ROVPPB 3     // ROVpp 0.2 (Blackhole Announcements)

--- a/include/Announcements/ROVAnnouncement.h
+++ b/include/Announcements/ROVAnnouncement.h
@@ -1,0 +1,23 @@
+#ifndef ROV_ANNOUNCEMENT_H
+#define ROV_ANNOUNCEMENT_H
+
+#include "Announcements/Announcement.h"
+
+class ROVAnnouncement : public Announcement {
+public:
+    /** Default constructor
+     */
+    ROVAnnouncement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask,
+        uint32_t from_asn, int64_t timestamp = 0);
+    
+    /** Priority constructor
+     */
+    ROVAnnouncement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask,
+        uint32_t pr, uint32_t from_asn, int64_t timestamp, bool a_from_monitor = false);
+
+    /** Copy constructor
+     */
+    ROVAnnouncement(const ROVAnnouncement& ann);
+};
+
+#endif

--- a/include/Announcements/ROVppAnnouncement.h
+++ b/include/Announcements/ROVppAnnouncement.h
@@ -21,8 +21,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  ************************************************************************/
 
-#ifndef ROV_ANNOUNCEMENT_H
-#define ROV_ANNOUNCEMENT_H
+#ifndef ROVPP_ANNOUNCEMENT_H
+#define ROVPP_ANNOUNCEMENT_H
 
 #include "Announcements/Announcement.h"
 

--- a/include/Extrapolators/BaseExtrapolator.h
+++ b/include/Extrapolators/BaseExtrapolator.h
@@ -61,6 +61,11 @@
 #include "Announcements/EZAnnouncement.h"
 #include "ASes/EZAS.h"
 
+#include "SQLQueriers/ROVSQLQuerier.h"
+#include "Graphs/ROVASGraph.h"
+#include "Announcements/ROVAnnouncement.h"
+#include "ASes/ROVAS.h"
+
 /** README. SERIOUSLY README
  * Trust me you need to read this.
  * 

--- a/include/Extrapolators/ROVExtrapolator.h
+++ b/include/Extrapolators/ROVExtrapolator.h
@@ -8,6 +8,11 @@
 #include "Announcements/ROVAnnouncement.h"
 #include "ASes/ROVAS.h"
 
+/**
+ * This Extrapolator implements ROV policy
+ * In short, ASes that adopt ROV check whether an announcement is valid
+ * by looking at its origin. If the origin AS is an attacker, the announcement is rejected
+*/
 class ROVExtrapolator : public BlockedExtrapolator<ROVSQLQuerier, ROVASGraph, ROVAnnouncement, ROVAS> {
 public:
     ROVExtrapolator(bool random_tiebraking,
@@ -27,7 +32,20 @@ public:
     ROVExtrapolator();
     ~ROVExtrapolator();
 
+    /** Process a set of prefix or subnet blocks in iterations.
+    */
     void extrapolate_blocks(uint32_t &announcement_count, int &iteration, bool subnet, std::vector<Prefix<>*> *prefix_set);
+
+    /** Seed announcement on all ASes on as_path. 
+     *
+     * The from_monitor attribute is set to true on these announcements so they are
+     * not replaced later during propagation. 
+     * 
+     * @param as_path Vector of ASNs for this announcement.
+     * @param prefix The prefix this announcement is for.
+     * @param timestamp Timestamp of this announcement.
+     * @param roa_validity Validity of this announcement. 0 = valid, 1 = unknown, etc.
+     */
     void give_ann_to_as_path(std::vector<uint32_t>* as_path, Prefix<> prefix, int64_t timestamp = 0, uint32_t roa_validity = 1);
 };
 

--- a/include/Extrapolators/ROVExtrapolator.h
+++ b/include/Extrapolators/ROVExtrapolator.h
@@ -1,0 +1,38 @@
+#ifndef ROV_EXTRAPOLATOR_H
+#define ROV_EXTRAPOLATOR_H
+
+#include "Extrapolators/BlockedExtrapolator.h"
+
+#include "SQLQueriers/ROVSQLQuerier.h"
+#include "Graphs/ROVASGraph.h"
+#include "Announcements/ROVAnnouncement.h"
+#include "ASes/ROVAS.h"
+
+class ROVExtrapolator : public BlockedExtrapolator<ROVSQLQuerier, ROVASGraph, ROVAnnouncement, ROVAS> {
+public:
+    ROVExtrapolator(bool random_tiebraking,
+                    bool store_results, 
+                    bool store_invert_results, 
+                    bool store_depref_results, 
+                    std::vector<std::string> policy_tables,
+                    std::string announcement_table,
+                    std::string results_table, 
+                    std::string inverse_results_table, 
+                    std::string depref_results_table, 
+                    std::string full_path_results_table, 
+                    std::string config_section,
+                    uint32_t iteration_size,
+                    int exclude_as_number,
+                    uint32_t mh_mode,
+                    bool origin_only,
+                    std::vector<uint32_t> *full_path_asns,
+                    int max_threads);
+    
+    ROVExtrapolator();
+    ~ROVExtrapolator();
+
+    void extrapolate_blocks(uint32_t &announcement_count, int &iteration, bool subnet, std::vector<Prefix<>*> *prefix_set);
+    void give_ann_to_as_path(std::vector<uint32_t>* as_path, Prefix<> prefix, int64_t timestamp = 0, uint32_t roa_validity = 1);
+};
+
+#endif

--- a/include/Extrapolators/ROVExtrapolator.h
+++ b/include/Extrapolators/ROVExtrapolator.h
@@ -12,13 +12,9 @@ class ROVExtrapolator : public BlockedExtrapolator<ROVSQLQuerier, ROVASGraph, RO
 public:
     ROVExtrapolator(bool random_tiebraking,
                     bool store_results, 
-                    bool store_invert_results, 
-                    bool store_depref_results, 
                     std::vector<std::string> policy_tables,
                     std::string announcement_table,
                     std::string results_table, 
-                    std::string inverse_results_table, 
-                    std::string depref_results_table, 
                     std::string full_path_results_table, 
                     std::string config_section,
                     uint32_t iteration_size,

--- a/include/Graphs/BaseGraph.h
+++ b/include/Graphs/BaseGraph.h
@@ -42,6 +42,7 @@ class SQLQuerier;
 #include "ASes/AS.h"
 #include "ASes/EZAS.h"
 #include "ASes/ROVppAS.h"
+#include "ASes/ROVAS.h"
 
 #include "SQLQueriers/SQLQuerier.h"
 #include "TableNames.h"

--- a/include/Graphs/ROVASGraph.h
+++ b/include/Graphs/ROVASGraph.h
@@ -10,7 +10,7 @@ public:
     ROVASGraph(bool store_inverse_results, bool store_depref_results);
     ROVASGraph();
     ~ROVASGraph();
-    ROVAS* create_new(uint32_t asn);
+    ROVAS* createNew(uint32_t asn);
     void process(SQLQuerier *querier);
     void create_graph_from_db(ROVSQLQuerier *querier);
     void add_attacker(uint32_t asn);

--- a/include/Graphs/ROVASGraph.h
+++ b/include/Graphs/ROVASGraph.h
@@ -10,7 +10,7 @@ public:
     ROVASGraph(bool store_inverse_results, bool store_depref_results);
     ROVASGraph();
     ~ROVASGraph();
-    ROVAS* createNew(uint32_t asn);
+    ROVAS* create_new(uint32_t asn);
     void process(SQLQuerier *querier);
     void create_graph_from_db(ROVSQLQuerier *querier);
     void add_attacker(uint32_t asn);

--- a/include/Graphs/ROVASGraph.h
+++ b/include/Graphs/ROVASGraph.h
@@ -1,0 +1,22 @@
+#ifndef ROV_AS_GRAPH_H
+#define ROV_AS_GRAPH_H
+
+#include "ASes/ROVAS.h"
+#include "Graphs/BaseGraph.h"
+#include "SQLQueriers/ROVSQLQuerier.h"
+
+class ROVASGraph : public BaseGraph<ROVAS> {
+public:
+    ROVASGraph(bool store_inverse_results, bool store_depref_results);
+    ROVASGraph();
+    ~ROVASGraph();
+    ROVAS* createNew(uint32_t asn);
+    void process(SQLQuerier *querier);
+    void create_graph_from_db(ROVSQLQuerier *querier);
+    void add_attacker(uint32_t asn);
+
+private:
+    // Set of ASNs to keep track of attackers
+    std::set<uint32_t> *attackers;
+};
+#endif

--- a/include/Graphs/ROVASGraph.h
+++ b/include/Graphs/ROVASGraph.h
@@ -11,8 +11,26 @@ public:
     ROVASGraph();
     ~ROVASGraph();
     ROVAS* createNew(uint32_t asn);
+
+    /** Process the graph without removing stubs (needs querier to save them).
+     * 
+     * @param querier
+    */
     void process(SQLQuerier *querier);
+
+    /** Generates an ROVASGraph from relationship data in an SQL database based upon:
+     *      1) A populated peers table
+     *      2) A populated customer_providers table
+     *      3) Populated policy tables
+     * 
+     * @param querier
+     */
     void create_graph_from_db(ROVSQLQuerier *querier);
+
+    /** The asn passed in this function will be added to the list of attackers
+     * 
+     * @param asn AS number of an attacker
+     */
     void add_attacker(uint32_t asn);
 
 private:

--- a/include/SQLQueriers/ROVSQLQuerier.h
+++ b/include/SQLQueriers/ROVSQLQuerier.h
@@ -9,13 +9,15 @@ public:
 
     ROVSQLQuerier(std::vector<std::string> policy_tables = std::vector<std::string>(),
                     std::string announcements_table = ANNOUNCEMENTS_TABLE, 
-                    std::string results_table = RESULTS_TABLE,
+                    std::string results_table = SIMULATION_RESULTS_TABLE,
                     std::string full_path_results_table = FULL_PATH_RESULTS_TABLE,
                     int exclude_as_number = -1,
                     std::string config_section = DEFAULT_QUERIER_CONFIG_SECTION);
     ~ROVSQLQuerier();
 
     pqxx::result select_AS_flags(std::string const& policy_table = std::string("edge_ases"));
+    pqxx::result select_prefix_ann(Prefix<>* p);
+    pqxx::result select_subnet_ann(Prefix<>* p);
 };
 
 #endif

--- a/include/SQLQueriers/ROVSQLQuerier.h
+++ b/include/SQLQueriers/ROVSQLQuerier.h
@@ -8,13 +8,11 @@ public:
     std::vector<std::string> policy_tables;
 
     ROVSQLQuerier(std::vector<std::string> policy_tables = std::vector<std::string>(),
-                    std::string a=ANNOUNCEMENTS_TABLE, 
-                    std::string r=RESULTS_TABLE,
-                    std::string i=INVERSE_RESULTS_TABLE,
-                    std::string d=DEPREF_RESULTS_TABLE,
-                    std::string f=FULL_PATH_RESULTS_TABLE,
-                    int n=-1,
-                    std::string s=DEFAULT_QUERIER_CONFIG_SECTION);
+                    std::string announcements_table = ANNOUNCEMENTS_TABLE, 
+                    std::string results_table = RESULTS_TABLE,
+                    std::string full_path_results_table = FULL_PATH_RESULTS_TABLE,
+                    int exclude_as_number = -1,
+                    std::string config_section = DEFAULT_QUERIER_CONFIG_SECTION);
     ~ROVSQLQuerier();
 
     pqxx::result select_AS_flags(std::string const& policy_table = std::string("edge_ases"));

--- a/include/SQLQueriers/ROVSQLQuerier.h
+++ b/include/SQLQueriers/ROVSQLQuerier.h
@@ -1,0 +1,23 @@
+#ifndef ROV_SQL_QUERIER_H
+#define ROV_SQL_QUERIER_H
+
+#include "SQLQueriers/SQLQuerier.h"
+
+class ROVSQLQuerier : public SQLQuerier {
+public:
+    std::vector<std::string> policy_tables;
+
+    ROVSQLQuerier(std::vector<std::string> policy_tables = std::vector<std::string>(),
+                    std::string a=ANNOUNCEMENTS_TABLE, 
+                    std::string r=RESULTS_TABLE,
+                    std::string i=INVERSE_RESULTS_TABLE,
+                    std::string d=DEPREF_RESULTS_TABLE,
+                    std::string f=FULL_PATH_RESULTS_TABLE,
+                    int n=-1,
+                    std::string s=DEFAULT_QUERIER_CONFIG_SECTION);
+    ~ROVSQLQuerier();
+
+    pqxx::result select_AS_flags(std::string const& policy_table = std::string("edge_ases"));
+};
+
+#endif

--- a/include/SQLQueriers/ROVSQLQuerier.h
+++ b/include/SQLQueriers/ROVSQLQuerier.h
@@ -15,8 +15,22 @@ public:
                     std::string config_section = DEFAULT_QUERIER_CONFIG_SECTION);
     ~ROVSQLQuerier();
 
+    /** Pulls all ASes and policies they implement.
+     *
+     * @param policy_table The table name holding the list of ASNs with their policies, default is 'edge_ases'
+     */
     pqxx::result select_AS_flags(std::string const& policy_table = std::string("edge_ases"));
+
+    /** Pulls all announcements for the announcements for the given prefix.
+     *
+     * @param p The prefix for which we SELECT
+     */
     pqxx::result select_prefix_ann(Prefix<>* p);
+
+    /** Pulls all announcements for the prefixes contained within the passed subnet.
+     *
+     * @param p The prefix defining the subnet
+     */
     pqxx::result select_subnet_ann(Prefix<>* p);
 };
 

--- a/include/SQLQueriers/ROVSQLQuerier.h
+++ b/include/SQLQueriers/ROVSQLQuerier.h
@@ -8,7 +8,7 @@ public:
     std::vector<std::string> policy_tables;
 
     ROVSQLQuerier(std::vector<std::string> policy_tables = std::vector<std::string>(),
-                    std::string announcements_table = ANNOUNCEMENTS_TABLE, 
+                    std::string announcements_table = ROV_ANNOUNCEMENTS_TABLE, 
                     std::string results_table = SIMULATION_RESULTS_TABLE,
                     std::string full_path_results_table = FULL_PATH_RESULTS_TABLE,
                     int exclude_as_number = -1,

--- a/include/TableNames.h
+++ b/include/TableNames.h
@@ -36,6 +36,9 @@
 #define SUPERNODES_TABLE "supernodes"
 #define ANNOUNCEMENTS_TABLE "mrt_w_roas"
 
+// Simulation Tables
+#define SIMULATION_RESULTS_TABLE "simulation_extrapolation_results_raw_round_1"
+
 // ROV++ Tables
 #define ROVPP_POLICY_TABLE "rovpp_ases"
 #define ROVPP_TOP_TABLE "rovpp_top_100_ases"

--- a/include/TableNames.h
+++ b/include/TableNames.h
@@ -38,6 +38,7 @@
 
 // Simulation Tables
 #define SIMULATION_RESULTS_TABLE "simulation_extrapolation_results_raw_round_1"
+#define ROV_ANNOUNCEMENTS_TABLE "mrt_w_metadata"
 
 // ROV++ Tables
 #define ROVPP_POLICY_TABLE "rovpp_ases"

--- a/include/Tests/Tests.h
+++ b/include/Tests/Tests.h
@@ -155,6 +155,22 @@ bool test_rovpp_prepending_priority_middle_existing_ann();
 bool test_rovpp_prepending_priority_beginning_existing_ann();
 bool test_rovpp_prepending_priority_beginning_existing_ann2();
 
+//ROV Reference
+bool test_rov_constructor();
+bool test_rov_is_attacker();
+bool test_rov_is_from_attacker();
+bool test_rov_give_ann_to_as_path();
+bool test_rov_give_ann_to_as_path_invalid();
+bool test_rov_send_all_announcements();
+bool test_rov_process_announcement();
+bool test_rov_prepending_priority_back();
+bool test_rov_prepending_priority_middle();
+bool test_rov_prepending_priority_beginning();
+bool test_rov_prepending_priority_back_existing_ann();
+bool test_rov_prepending_priority_middle_existing_ann();
+bool test_rov_prepending_priority_beginning_existing_ann();
+bool test_rov_prepending_priority_beginning_existing_ann2();
+
 //EZBGPsec
 bool ezbgpsec_test_path_propagation();
 

--- a/main.cpp
+++ b/main.cpp
@@ -33,6 +33,7 @@
 #include "Extrapolators/Extrapolator.h"
 #include "Extrapolators/ROVppExtrapolator.h"
 #include "Extrapolators/EZExtrapolator.h"
+#include "Extrapolators/ROVExtrapolator.h"
 #include "Tests/Tests.h"
 
 #include <boost/log/core.hpp>
@@ -65,6 +66,9 @@ int main(int argc, char *argv[]) {
         ("rovpp,v", 
          po::value<bool>()->default_value(false), 
          "flag for rovpp run")
+        ("rov", 
+         po::value<bool>()->default_value(false), 
+         "flag for rov run")
         ("ezbgpsec,z", 
          po::value<uint32_t>()->default_value(0), 
          "number of rounds for ezbgpsec run")
@@ -196,6 +200,43 @@ int main(int argc, char *argv[]) {
         // Run propagation
         bool prop_twice = vm["prop-twice"].as<bool>();
         extrap->perform_propagation(prop_twice);
+        // Clean up
+        delete extrap;
+    } else if (vm["rov"].as<bool>()) {
+        // Instantiate Extrapolator
+        ROVExtrapolator *extrap = new ROVExtrapolator(
+            vm["random"].as<bool>(),
+            vm["store-results"].as<bool>(),
+            vm["store-inverse-results"].as<bool>(),
+            vm["store-depref"].as<bool>(),
+            (vm.count("policy-tables") ?
+                vm["policy-tables"].as<vector<string>>() : 
+                vector<string>()),
+            (vm.count("announcements-table") ? 
+                vm["announcements-table"].as<string>() : 
+                ANNOUNCEMENTS_TABLE),
+            (vm.count("results-table") ?
+                vm["results-table"].as<string>() :
+                RESULTS_TABLE),
+            (vm.count("inverse-results-table") ?
+                vm["inverse-results-table"].as<string>() : 
+                INVERSE_RESULTS_TABLE),
+            (vm.count("depref-table") ?
+                vm["depref-table"].as<string>() : 
+                DEPREF_RESULTS_TABLE),
+            (vm.count("full-path-results-table") ?
+                vm["full-path-results-table"].as<string>() :
+                FULL_PATH_RESULTS_TABLE),
+            vm["config-section"].as<string>(),
+            vm["iteration-size"].as<uint32_t>(),
+            vm["exclude-monitor"].as<int>(),
+            vm["mh-propagation-mode"].as<uint32_t>(),
+            vm["origin-only"].as<bool>(),
+            full_path_asns,
+            vm["max-threads"].as<uint32_t>());
+            
+        // Run propagation
+        extrap->perform_propagation();
         // Clean up
         delete extrap;
     } else if(vm["ezbgpsec"].as<uint32_t>()) {

--- a/main.cpp
+++ b/main.cpp
@@ -212,10 +212,10 @@ int main(int argc, char *argv[]) {
                 vector<string>()),
             (vm.count("announcements-table") ? 
                 vm["announcements-table"].as<string>() : 
-                ANNOUNCEMENTS_TABLE),
+                ROV_ANNOUNCEMENTS_TABLE),
             (vm.count("results-table") ?
                 vm["results-table"].as<string>() :
-                RESULTS_TABLE),
+                SIMULATION_RESULTS_TABLE),
             (vm.count("full-path-results-table") ?
                 vm["full-path-results-table"].as<string>() :
                 FULL_PATH_RESULTS_TABLE),

--- a/main.cpp
+++ b/main.cpp
@@ -207,8 +207,6 @@ int main(int argc, char *argv[]) {
         ROVExtrapolator *extrap = new ROVExtrapolator(
             vm["random"].as<bool>(),
             vm["store-results"].as<bool>(),
-            vm["store-inverse-results"].as<bool>(),
-            vm["store-depref"].as<bool>(),
             (vm.count("policy-tables") ?
                 vm["policy-tables"].as<vector<string>>() : 
                 vector<string>()),
@@ -218,12 +216,6 @@ int main(int argc, char *argv[]) {
             (vm.count("results-table") ?
                 vm["results-table"].as<string>() :
                 RESULTS_TABLE),
-            (vm.count("inverse-results-table") ?
-                vm["inverse-results-table"].as<string>() : 
-                INVERSE_RESULTS_TABLE),
-            (vm.count("depref-table") ?
-                vm["depref-table"].as<string>() : 
-                DEPREF_RESULTS_TABLE),
             (vm.count("full-path-results-table") ?
                 vm["full-path-results-table"].as<string>() :
                 FULL_PATH_RESULTS_TABLE),

--- a/src/ASes/BaseAS.cpp
+++ b/src/ASes/BaseAS.cpp
@@ -295,3 +295,4 @@ std::ostream& BaseAS<AnnouncementType>::stream_depref(std::ostream &os) {
 template class BaseAS<Announcement>;
 template class BaseAS<EZAnnouncement>;
 template class BaseAS<ROVppAnnouncement>;
+template class BaseAS<ROVAnnouncement>;

--- a/src/ASes/ROVAS.cpp
+++ b/src/ASes/ROVAS.cpp
@@ -7,32 +7,10 @@ ROVAS::ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers, bool store_depref_
     // ROV adoption is false by default
     adopts_rov = false;
 }
-ROVAS::ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers, bool store_depref_results) 
-: BaseAS<ROVAnnouncement>(asn, store_depref_results, NULL) { 
-    // Save reference to attackers
-    attackers = rov_attackers;
-    // ROV adoption is false by default
-    adopts_rov = false;
-}
-ROVAS::ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers)
-: BaseAS<ROVAnnouncement>(asn, false, NULL) { 
-    // Save reference to attackers
-    attackers = rov_attackers;
-    // ROV adoption is false by default
-    adopts_rov = false;
-}
-ROVAS::ROVAS(uint32_t asn)
-: BaseAS<ROVAnnouncement>(asn, false, NULL) { 
-    // Save reference to attackers
-    attackers = new std::set<uint32_t>();
-    // ROV adoption is false by default
-    adopts_rov = false;
-}
-ROVAS::ROVAS() : ROVAS(0, NULL, false, NULL) {
-    attackers = new std::set<uint32_t>();
-    // ROV adoption is false by default
-    adopts_rov = false;
- }
+ROVAS::ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers, bool store_depref_results) : ROVAS(asn, rov_attackers, store_depref_results, NULL) {}
+ROVAS::ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers) : ROVAS(asn, rov_attackers, false, NULL) {}
+ROVAS::ROVAS(uint32_t asn) : ROVAS(asn, NULL, false, NULL) {}
+ROVAS::ROVAS() : ROVAS(0, NULL, false, NULL) {}
 
 ROVAS::~ROVAS() {}
 

--- a/src/ASes/ROVAS.cpp
+++ b/src/ASes/ROVAS.cpp
@@ -4,19 +4,37 @@ ROVAS::ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers, bool store_depref_
 : BaseAS<ROVAnnouncement>(asn, store_depref_results, inverse_results) { 
     // Save reference to attackers
     attackers = rov_attackers;
+    // ROV adoption is false by default
+    adopts_rov = false;
 }
 ROVAS::ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers, bool store_depref_results) 
 : BaseAS<ROVAnnouncement>(asn, store_depref_results, NULL) { 
     // Save reference to attackers
     attackers = rov_attackers;
+    // ROV adoption is false by default
+    adopts_rov = false;
 }
 ROVAS::ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers)
 : BaseAS<ROVAnnouncement>(asn, false, NULL) { 
     // Save reference to attackers
     attackers = rov_attackers;
+    // ROV adoption is false by default
+    adopts_rov = false;
 }
-ROVAS::ROVAS() : ROVAS(0, NULL, false, NULL) { }
-ROVAS::~ROVAS() { }
+ROVAS::ROVAS(uint32_t asn)
+: BaseAS<ROVAnnouncement>(asn, false, NULL) { 
+    // Save reference to attackers
+    attackers = new std::set<uint32_t>();
+    // ROV adoption is false by default
+    adopts_rov = false;
+}
+ROVAS::ROVAS() : ROVAS(0, NULL, false, NULL) {
+    attackers = new std::set<uint32_t>();
+    // ROV adoption is false by default
+    adopts_rov = false;
+ }
+
+ROVAS::~ROVAS() {}
 
 void ROVAS::process_announcement(ROVAnnouncement &ann, bool ran) {
     std::cout << "processing ann" << std::endl;

--- a/src/ASes/ROVAS.cpp
+++ b/src/ASes/ROVAS.cpp
@@ -1,0 +1,62 @@
+#include "ASes/ROVAS.h"
+
+ROVAS::ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers, bool store_depref_results, std::map<std::pair<Prefix<>, uint32_t>, std::set<uint32_t>*> *inverse_results) 
+: BaseAS<ROVAnnouncement>(asn, store_depref_results, inverse_results) { 
+    // Save reference to attackers
+    attackers = rov_attackers;
+}
+ROVAS::ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers, bool store_depref_results) 
+: BaseAS<ROVAnnouncement>(asn, store_depref_results, NULL) { 
+    // Save reference to attackers
+    attackers = rov_attackers;
+}
+ROVAS::ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers)
+: BaseAS<ROVAnnouncement>(asn, false, NULL) { 
+    // Save reference to attackers
+    attackers = rov_attackers;
+}
+ROVAS::ROVAS() : ROVAS(0, NULL, false, NULL) { }
+ROVAS::~ROVAS() { }
+
+void ROVAS::process_announcement(ROVAnnouncement &ann, bool ran) {
+    std::cout << "processing ann" << std::endl;
+    std::cout << "asn: " << this->asn << ", adopts: " << adopts_rov << std::endl;
+
+    if (!adopts_rov) {
+        // If this AS doesn't adopt ROV, process the announcement
+        std::cout << "PROCESSED ann, doesn't adopt" << std::endl;
+        BaseAS::process_announcement(ann, ran);
+    } else if (is_attacker()) {
+        // If this AS is an attacker, process the announcement
+        std::cout << "PROCESSED ann, attacker" << std::endl;
+        BaseAS::process_announcement(ann, ran);
+    } else if (adopts_rov && !is_from_attacker(ann)) {
+        // If this AS adopts ROV, but the announcement is not from an attacker, process it
+        std::cout << "PROCESSED ann, not from attacker" << std::endl;
+        BaseAS::process_announcement(ann, ran);
+    }
+}
+
+bool ROVAS::is_from_attacker(ROVAnnouncement &ann) {
+    if (attackers != NULL) {
+        return !(attackers->find(ann.origin) == attackers->end());
+    } else {
+        return false;
+    }
+}
+
+bool ROVAS::is_attacker() {
+    if (attackers != NULL) {
+        return !(attackers->find(this->asn) == attackers->end());
+    } else {
+        return false;
+    }
+}
+
+void ROVAS::set_rov_adoption(bool adopts_rov) {
+    this->adopts_rov = adopts_rov;
+}
+
+bool ROVAS::get_rov_adoption() {
+    return adopts_rov;
+}

--- a/src/ASes/ROVAS.cpp
+++ b/src/ASes/ROVAS.cpp
@@ -11,24 +11,17 @@ ROVAS::ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers, bool store_depref_
 ROVAS::ROVAS(uint32_t asn, std::set<uint32_t> *rov_attackers) : ROVAS(asn, rov_attackers, false, NULL) {}
 ROVAS::ROVAS(uint32_t asn) : ROVAS(asn, NULL, false, NULL) {}
 ROVAS::ROVAS() : ROVAS(0, NULL, false, NULL) {}
-
 ROVAS::~ROVAS() {}
 
 void ROVAS::process_announcement(ROVAnnouncement &ann, bool ran) {
-    std::cout << "processing ann" << std::endl;
-    std::cout << "asn: " << this->asn << ", adopts: " << adopts_rov << std::endl;
-
     if (!adopts_rov) {
         // If this AS doesn't adopt ROV, process the announcement
-        std::cout << "PROCESSED ann, doesn't adopt" << std::endl;
         BaseAS::process_announcement(ann, ran);
     } else if (is_attacker()) {
         // If this AS is an attacker, process the announcement
-        std::cout << "PROCESSED ann, attacker" << std::endl;
         BaseAS::process_announcement(ann, ran);
     } else if (adopts_rov && !is_from_attacker(ann)) {
         // If this AS adopts ROV, but the announcement is not from an attacker, process it
-        std::cout << "PROCESSED ann, not from attacker" << std::endl;
         BaseAS::process_announcement(ann, ran);
     }
 }

--- a/src/Announcements/ROVAnnouncement.cpp
+++ b/src/Announcements/ROVAnnouncement.cpp
@@ -1,0 +1,9 @@
+#include "Announcements/ROVAnnouncement.h"
+
+ROVAnnouncement::ROVAnnouncement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask,
+    uint32_t from_asn, int64_t timestamp /* = 0 */) : Announcement(aorigin, aprefix, anetmask, from_asn, timestamp) {}
+
+ROVAnnouncement::ROVAnnouncement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask,
+    uint32_t pr, uint32_t from_asn, int64_t timestamp, bool a_from_monitor /* = false */) : Announcement(aorigin, aprefix, anetmask, pr, from_asn, timestamp, a_from_monitor) {}
+
+ROVAnnouncement::ROVAnnouncement(const ROVAnnouncement& ann) : Announcement(ann) {}

--- a/src/Extrapolators/BaseExtrapolator.cpp
+++ b/src/Extrapolators/BaseExtrapolator.cpp
@@ -286,3 +286,4 @@ std::string BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType
 template class BaseExtrapolator<SQLQuerier, ASGraph, Announcement, AS>;
 template class BaseExtrapolator<EZSQLQuerier, EZASGraph, EZAnnouncement, EZAS>;
 template class BaseExtrapolator<ROVppSQLQuerier, ROVppASGraph, ROVppAnnouncement, ROVppAS>;
+template class BaseExtrapolator<ROVSQLQuerier, ROVASGraph, ROVAnnouncement, ROVAS>;

--- a/src/Extrapolators/BlockedExtrapolator.cpp
+++ b/src/Extrapolators/BlockedExtrapolator.cpp
@@ -601,3 +601,4 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::s
 
 template class BlockedExtrapolator<SQLQuerier, ASGraph, Announcement, AS>;
 template class BlockedExtrapolator<EZSQLQuerier, EZASGraph, EZAnnouncement, EZAS>;
+template class BlockedExtrapolator<ROVSQLQuerier, ROVASGraph, ROVAnnouncement, ROVAS>;

--- a/src/Extrapolators/ROVExtrapolator.cpp
+++ b/src/Extrapolators/ROVExtrapolator.cpp
@@ -1,0 +1,298 @@
+#include "Extrapolators/ROVExtrapolator.h"
+
+//Need to check if the origin can reach the victim!
+//Attacker is checked for this, the origin needs to as well
+
+ROVExtrapolator::ROVExtrapolator(bool random_tiebraking,
+                                bool store_results, 
+                                bool store_invert_results, 
+                                bool store_depref_results, 
+                                std::vector<std::string> policy_tables,
+                                std::string announcement_table,
+                                std::string results_table, 
+                                std::string inverse_results_table, 
+                                std::string depref_results_table, 
+                                std::string full_path_results_table, 
+                                std::string config_section,
+                                uint32_t iteration_size,
+                                int exclude_as_number,
+                                uint32_t mh_mode,
+                                bool origin_only,
+                                std::vector<uint32_t> *full_path_asns,
+                                int max_threads) : BlockedExtrapolator(random_tiebraking, store_results, store_invert_results, store_depref_results, 
+                                iteration_size, mh_mode, origin_only, full_path_asns, max_threads) {
+    
+    graph = new ROVASGraph(store_invert_results, store_depref_results);
+    querier = new ROVSQLQuerier(policy_tables, announcement_table, results_table, inverse_results_table, depref_results_table, full_path_results_table, exclude_as_number, config_section);
+}
+
+ROVExtrapolator::ROVExtrapolator() 
+    : ROVExtrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, std::vector<std::string>(),
+                        ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, 
+                        DEFAULT_ITERATION_SIZE, -1, DEFAULT_MH_MODE, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_MAX_THREADS) { }
+
+ROVExtrapolator::~ROVExtrapolator() { }
+
+void ROVExtrapolator::extrapolate_blocks(uint32_t &announcement_count, int &iteration, bool subnet, std::vector<Prefix<>*> *prefix_set) {
+    // For each unprocessed block of announcements 
+    for (Prefix<>* prefix : *prefix_set) {
+        BOOST_LOG_TRIVIAL(info) << "Selecting Announcements...";
+        auto prefix_start = std::chrono::high_resolution_clock::now();
+        
+        // Handle prefix blocks or subnet blocks of announcements
+        pqxx::result ann_block;
+        if (!subnet) {
+            // Get the block of announcements for the specific prefix
+            ann_block = this->querier->select_prefix_ann(prefix);
+        } else {
+            // Get the block of announcements for the whole subnet
+            ann_block = this->querier->select_subnet_ann(prefix);
+        } 
+        
+        // Check for empty block
+        auto bsize = ann_block.size();
+        if (bsize == 0)
+            break;
+        announcement_count += bsize;
+        
+        BOOST_LOG_TRIVIAL(info) << "Seeding announcements...";
+        // For all announcements in this block
+        for (pqxx::result::size_type i = 0; i < bsize; i++) {
+            // Get row origin
+            uint32_t origin;
+            ann_block[i]["origin"].to(origin);
+            // Get row prefix
+            std::string ip = ann_block[i]["host"].c_str();
+            std::string mask = ann_block[i]["netmask"].c_str();
+            Prefix<> cur_prefix(ip, mask);
+            // Get row AS path
+            std::string path_as_string(ann_block[i]["as_path"].as<std::string>());
+            std::vector<uint32_t> *as_path = this->parse_path(path_as_string);
+            
+            // Check for loops in the path and drop announcement if they exist
+            bool loop = this->find_loop(as_path);
+            if (loop) {
+                static int g_loop = 1;
+                
+                // Logger::getInstance().log("Loops") << "AS path loop #" << g_loop << ", Origin: " << origin << ", Prefix: " << cur_prefix.to_cidr() << ", Path: " << path_as_string;
+
+                g_loop++;
+                continue;
+            }
+
+            // Get timestamp
+            int64_t timestamp = std::stol(ann_block[i]["time"].as<std::string>());
+
+            // Get validity of an announcement
+            int32_t roa_validity = std::stol(ann_block[i]["roa_validity"].as<std::string>());
+
+            if(this->graph->inverse_results != NULL) {
+                // Assemble pair
+                auto prefix_origin = std::pair<Prefix<>, uint32_t>(cur_prefix, origin);
+                
+                // Insert the inverse results for this prefix
+                if (this->graph->inverse_results->find(prefix_origin) == this->graph->inverse_results->end()) {
+                    // This is horrifying
+                    this->graph->inverse_results->insert(std::pair<std::pair<Prefix<>, uint32_t>, 
+                                                            std::set<uint32_t>*>
+                                                            (prefix_origin, new std::set<uint32_t>()));
+                    
+                    // Put all non-stub ASNs in the set
+                    for (uint32_t asn : *this->graph->non_stubs) {
+                        this->graph->inverse_results->find(prefix_origin)->second->insert(asn);
+                    }
+                }
+            }
+
+            // Seed announcements along AS path
+            this->give_ann_to_as_path(as_path, cur_prefix, timestamp, roa_validity);
+            delete as_path;
+        }
+        // Propagate for this subnet
+        BOOST_LOG_TRIVIAL(info) << "Propagating...";
+        this->propagate_up();
+        this->propagate_down();
+        this->save_results(iteration);
+        this->graph->clear_announcements();
+        iteration++;
+        
+        BOOST_LOG_TRIVIAL(info) << prefix->to_cidr() << " completed.";
+        auto prefix_finish = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double> q = prefix_finish - prefix_start;
+    }
+}
+
+void ROVExtrapolator::give_ann_to_as_path(std::vector<uint32_t>* as_path, Prefix<> prefix, int64_t timestamp /* = 0 */, uint32_t roa_validity /* = 1 */) {
+    // Handle empty as_path
+    if (as_path->empty()) { 
+        return;
+    }
+    
+    uint32_t i = 0;
+    uint32_t path_l = as_path->size();
+    
+    // Announcement at origin for checking along the path
+    // AnnouncementType ann_to_check_for(as_path->at(path_l-1),
+    //                                     prefix.addr,
+    //                                     prefix.netmask,
+    //                                     0,
+    //                                     timestamp); 
+    
+    // Iterate through path starting at the origin
+    for (auto it = as_path->rbegin(); it != as_path->rend(); ++it) {
+        // Only seed at origin AS if origin only mode is enabled
+        if (this->origin_only == true && it != as_path->rbegin()) {
+            return;
+        }
+
+        // Increments path length, including prepending
+        i++;
+        // If ASN not in graph, continue
+        if (this->graph->ases->find(*it) == this->graph->ases->end()) {
+            continue;
+        }
+        // Translate ASN to it's supernode
+        uint32_t asn_on_path = this->graph->translate_asn(*it);
+        // Find the current AS on the path
+        ROVAS *as_on_path = this->graph->ases->find(asn_on_path)->second;
+
+        auto announcement_search = as_on_path->all_anns->find(prefix);
+
+        // If ASes in the path aren't neighbors (data is out of sync)
+        bool broken_path = false;
+
+        // It is 3 by default. It stays as 3 if it's the origin.
+        int received_from = 300;
+        // If this is not the origin AS
+        if (i > 1) {
+            // Get the previous ASes relationship to current AS
+            if (as_on_path->providers->find(*(it - 1)) != as_on_path->providers->end()) {
+                received_from = AS_REL_PROVIDER;
+            } else if (as_on_path->peers->find(*(it - 1)) != as_on_path->peers->end()) {
+                received_from = AS_REL_PEER;
+            } else if (as_on_path->customers->find(*(it - 1)) != as_on_path->customers->end()) {
+                received_from = AS_REL_CUSTOMER;
+            } else {
+                broken_path = true;
+            }
+        }
+
+        // This is how priority is calculated
+        uint32_t path_len_weighted = 100 - (i - 1);
+        uint32_t priority = received_from + path_len_weighted;
+
+        // Check if already received this prefix
+        if (announcement_search != as_on_path->all_anns->end()) {
+            ROVAnnouncement& second_announcement = announcement_search->second;
+
+            // If the current timestamp is newer (worse)
+            if (timestamp > second_announcement.tstamp) {
+                // Skip it
+                continue;
+            } else if (timestamp == second_announcement.tstamp) {
+                // Position of previous AS on path
+                uint32_t prevPos = path_l - i + 1;
+
+                // Position of the current AS on path
+                uint32_t currPos = path_l - i;
+
+                // Tie breaker for equal timestamp
+                bool keep_first = true;
+                // Random tiebreak if enabled
+                if (this->random_tiebraking) {
+                    keep_first = as_on_path->get_random();
+                }
+
+                // Skip announcement if there exists one with a higher priority
+                ROVAS *current_as = this->graph->ases->find(as_path->at(currPos))->second;
+                if (current_as->all_anns->find(prefix)->second.priority > priority) {
+                    continue;
+                // If the new announcement has a higher priority, change keep_first to false to make sure we save it
+                } else if (current_as->all_anns->find(prefix)->second.priority < priority) {
+                    keep_first = false;
+                }
+
+                // Log annoucements with equal timestamps 
+                // Logger::getInstance().log("Equal_Timestamp") << "Equal Timestamp on announcements. Prefix: " << prefix.to_cidr() << 
+                //     ", rand value: " << keep_first << ", tstamp on announcements: " << timestamp << 
+                //     ", origin on ann_to_check_for: " << as_path->at(path_l-1) << ", origin on stored announcement: " << second_announcement.origin;
+
+                // First come, first saved if random is disabled
+                if (keep_first) {
+                    continue;
+                } else {
+                    // Prepending check, use original priority
+                    if (prevPos < path_l && prevPos >= 0 && as_path->at(prevPos) == as_on_path->asn) {
+                        continue;
+                    }
+                    as_on_path->delete_ann(prefix);
+                }
+            } else {
+                // Log announcements that arent handled by sorting
+                // Logger::getInstance().log("Unsorted_Announcements") 
+                //     << "This announcement is being deleted and is not handled by sorting." 
+                //     << " Prefix: " << prefix.to_cidr() 
+                //     << ", tstamp: " << timestamp 
+                //     << ", origin: " << as_path->at(path_l-1);
+
+                // Delete worse MRT announcement, proceed with seeding
+                as_on_path->delete_ann(prefix);
+            }
+        }
+        
+        uint32_t received_from_asn = 0;
+
+        // ROV Handle origin received_from here
+        // HIJACKED = 64513
+        // NOTHIJACKED = 64514
+        
+        // If this AS is the origin
+        if (it == as_path->rbegin()){
+            // ROV: Set the received_from_asn to proper flag
+            if (roa_validity != 0 && roa_validity != 1) {
+                received_from_asn = HIJACKED_ASN;
+                // Mark this AS as an attacker
+                this->graph->add_attacker(asn_on_path);
+            } else {
+                received_from_asn = NOTHIJACKED_ASN;
+            }
+        } else {
+            // Otherwise received it from previous AS
+            received_from_asn = *(it-1);
+        }
+
+        // No break in path so send the announcement
+        if (!broken_path) {
+            ROVAnnouncement ann = ROVAnnouncement(*as_path->rbegin(),
+                                                    prefix.addr,
+                                                    prefix.netmask,
+                                                    priority,
+                                                    received_from_asn,
+                                                    timestamp,
+                                                    true);
+
+            std::cout << "Created ann, asn = " << as_on_path->asn << std::endl;
+
+            // Send the announcement to the current AS
+            as_on_path->process_announcement(ann, this->random_tiebraking);
+            if (this->graph->inverse_results != NULL) {
+                auto set = this->graph->inverse_results->find(
+                        std::pair<Prefix<>,uint32_t>(ann.prefix, ann.origin));
+                // Remove the AS from the prefix's inverse results
+                if (set != this->graph->inverse_results->end()) {
+                    set->second->erase(as_on_path->asn);
+                }
+            }
+        } else {
+            // Report the broken path
+            //std::cerr << "Broken path for " << *(it - 1) << ", " << *it << std::endl;
+            
+            static int g_broken_path = 0;
+
+            // Log the part of path where break takes place
+            // Logger::getInstance().log("Broken_Paths") << "Broken Path #" << g_broken_path << ", between these two ASes: " << *(it - 1) << ", " << *it;
+
+            g_broken_path++;
+        }
+    }
+}

--- a/src/Extrapolators/ROVExtrapolator.cpp
+++ b/src/Extrapolators/ROVExtrapolator.cpp
@@ -21,7 +21,7 @@ ROVExtrapolator::ROVExtrapolator(bool random_tiebraking,
 
 ROVExtrapolator::ROVExtrapolator() 
     : ROVExtrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, std::vector<std::string>(),
-                        ANNOUNCEMENTS_TABLE, RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, 
+                        ROV_ANNOUNCEMENTS_TABLE, SIMULATION_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, 
                         DEFAULT_ITERATION_SIZE, -1, DEFAULT_MH_MODE, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_MAX_THREADS) { }
 
 ROVExtrapolator::~ROVExtrapolator() { }

--- a/src/Graphs/BaseGraph.cpp
+++ b/src/Graphs/BaseGraph.cpp
@@ -457,3 +457,4 @@ std::ostream& operator<<(std::ostream &os, const BaseGraph<U>& asg) {
 template class BaseGraph<AS>;
 template class BaseGraph<EZAS>;
 template class BaseGraph<ROVppAS>;
+template class BaseGraph<ROVAS>;

--- a/src/Graphs/ROVASGraph.cpp
+++ b/src/Graphs/ROVASGraph.cpp
@@ -7,10 +7,11 @@ ROVASGraph::ROVASGraph() : BaseGraph(false, false) {
     attackers = new std::set<uint32_t>();
 }
 ROVASGraph::~ROVASGraph() {
-    delete attackers;
+    if (attackers != NULL)
+        delete attackers;
 }
 
-ROVAS* ROVASGraph::createNew(uint32_t asn) {
+ROVAS* ROVASGraph::create_new(uint32_t asn) {
     std::cout << "*** create new rov" << std::endl;
     return new ROVAS(asn, attackers, store_depref_results, inverse_results);
 }

--- a/src/Graphs/ROVASGraph.cpp
+++ b/src/Graphs/ROVASGraph.cpp
@@ -1,0 +1,65 @@
+#include "Graphs/ROVASGraph.h"
+
+ROVASGraph::ROVASGraph(bool store_inverse_results, bool store_depref_results) : BaseGraph(store_inverse_results, store_depref_results) {
+    attackers = new std::set<uint32_t>();
+}
+ROVASGraph::ROVASGraph() : BaseGraph(false, false) {
+    attackers = new std::set<uint32_t>();
+}
+ROVASGraph::~ROVASGraph() {
+    delete attackers;
+}
+
+ROVAS* ROVASGraph::createNew(uint32_t asn) {
+    std::cout << "*** create new rov" << std::endl;
+    return new ROVAS(asn, attackers, store_depref_results, inverse_results);
+}
+
+void ROVASGraph::process(SQLQuerier *querier) {
+    // remove_stubs isn't being called
+    tarjan();
+    combine_components();
+    save_supernodes_to_db(querier);
+    decide_ranks();
+    return;
+}
+
+void ROVASGraph::create_graph_from_db(ROVSQLQuerier *querier){
+    // Assemble Peers
+    pqxx::result R = querier->select_from_table(PEERS_TABLE);
+    for (pqxx::result::const_iterator c = R.begin(); c!=R.end(); ++c){
+        add_relationship(c["peer_as_1"].as<uint32_t>(),
+                         c["peer_as_2"].as<uint32_t>(),AS_REL_PEER);
+        add_relationship(c["peer_as_2"].as<uint32_t>(),
+                         c["peer_as_1"].as<uint32_t>(),AS_REL_PEER);
+    }
+    // Assemble Customer-Providers
+    R = querier->select_from_table(CUSTOMER_PROVIDER_TABLE);
+    for (pqxx::result::const_iterator c = R.begin(); c!=R.end(); ++c){
+        add_relationship(c["customer_as"].as<uint32_t>(),
+                         c["provider_as"].as<uint32_t>(),AS_REL_PROVIDER);
+        add_relationship(c["provider_as"].as<uint32_t>(),
+                         c["customer_as"].as<uint32_t>(),AS_REL_CUSTOMER);
+    }
+
+    // Assign the ROV policy to ASes that adopt it
+    for (auto policy_table : querier->policy_tables) {
+        R = querier->select_AS_flags(policy_table);
+        // For each AS in the policy Table
+        for (pqxx::result::const_iterator c = R.begin(); c != R.end(); ++c) {
+            // Get the ASN for current AS
+            auto search = ases->find(c["asn"].as<uint32_t>());
+            if (search != ases->end()) {
+                // If this AS adopts the ROV policy, change its adoption parameter to true
+                if (c["as_type"].as<uint32_t>() == ROVPPAS_TYPE_ROV)
+                    search->second->set_rov_adoption(true);
+            }
+        }
+    }
+    process(querier);
+    return;
+}
+
+void ROVASGraph::add_attacker(uint32_t asn) {
+    attackers->insert(asn);
+}

--- a/src/Graphs/ROVASGraph.cpp
+++ b/src/Graphs/ROVASGraph.cpp
@@ -10,7 +10,6 @@ ROVASGraph::~ROVASGraph() {
 }
 
 ROVAS* ROVASGraph::createNew(uint32_t asn) {
-    std::cout << "*** create new rov" << std::endl;
     return new ROVAS(asn, attackers, store_depref_results, inverse_results);
 }
 

--- a/src/Graphs/ROVASGraph.cpp
+++ b/src/Graphs/ROVASGraph.cpp
@@ -3,15 +3,13 @@
 ROVASGraph::ROVASGraph(bool store_inverse_results, bool store_depref_results) : BaseGraph(store_inverse_results, store_depref_results) {
     attackers = new std::set<uint32_t>();
 }
-ROVASGraph::ROVASGraph() : BaseGraph(false, false) {
-    attackers = new std::set<uint32_t>();
-}
+ROVASGraph::ROVASGraph() : ROVASGraph(false, false) {}
 ROVASGraph::~ROVASGraph() {
     if (attackers != NULL)
         delete attackers;
 }
 
-ROVAS* ROVASGraph::create_new(uint32_t asn) {
+ROVAS* ROVASGraph::createNew(uint32_t asn) {
     std::cout << "*** create new rov" << std::endl;
     return new ROVAS(asn, attackers, store_depref_results, inverse_results);
 }

--- a/src/SQLQueriers/ROVSQLQuerier.cpp
+++ b/src/SQLQueriers/ROVSQLQuerier.cpp
@@ -1,0 +1,17 @@
+#include "SQLQueriers/ROVSQLQuerier.h"
+
+ROVSQLQuerier::ROVSQLQuerier(std::vector<std::string> policy_tables, std::string a, std::string r, std::string i, std::string d, std::string f, int n, std::string s) 
+: SQLQuerier(a, r, i, d, f, n, s) {
+    this->policy_tables = policy_tables;
+}
+
+ROVSQLQuerier::~ROVSQLQuerier() { }
+
+/** Pulls all ASes and policies they implement.
+ *
+ * @param policy_table The table name holding the list of ASNs with their policies, default is 'edge_ases'
+ */
+pqxx::result ROVSQLQuerier::select_AS_flags(std::string const& policy_table){
+    std::string sql = "SELECT asn, as_type, impliment FROM " + policy_table + ";";
+    return execute(sql);
+}

--- a/src/SQLQueriers/ROVSQLQuerier.cpp
+++ b/src/SQLQueriers/ROVSQLQuerier.cpp
@@ -12,28 +12,16 @@ ROVSQLQuerier::ROVSQLQuerier(std::vector<std::string> policy_tables,
 
 ROVSQLQuerier::~ROVSQLQuerier() { }
 
-/** Pulls all ASes and policies they implement.
- *
- * @param policy_table The table name holding the list of ASNs with their policies, default is 'edge_ases'
- */
 pqxx::result ROVSQLQuerier::select_AS_flags(std::string const& policy_table){
     std::string sql = "SELECT asn, as_type, impliment FROM " + policy_table + ";";
     return execute(sql);
 }
 
-/** Pulls all announcements for the announcements for the given prefix.
- *
- * @param p The prefix for which we SELECT
- */
 pqxx::result ROVSQLQuerier::select_prefix_ann(Prefix<>* p) {
     std::string sql = select_prefix_query_string(p, false, "host(prefix), netmask(prefix), as_path, origin, time, roa_validity");
     return execute(sql);
 }
 
-/** Pulls all announcements for the prefixes contained within the passed subnet.
- *
- * @param p The prefix defining the subnet
- */
 pqxx::result ROVSQLQuerier::select_subnet_ann(Prefix<>* p) {
     std::string sql = select_prefix_query_string(p, true, "host(prefix), netmask(prefix), as_path, origin, time, roa_validity");
     return execute(sql);

--- a/src/SQLQueriers/ROVSQLQuerier.cpp
+++ b/src/SQLQueriers/ROVSQLQuerier.cpp
@@ -1,7 +1,12 @@
 #include "SQLQueriers/ROVSQLQuerier.h"
 
-ROVSQLQuerier::ROVSQLQuerier(std::vector<std::string> policy_tables, std::string a, std::string r, std::string i, std::string d, std::string f, int n, std::string s) 
-: SQLQuerier(a, r, i, d, f, n, s) {
+ROVSQLQuerier::ROVSQLQuerier(std::vector<std::string> policy_tables, 
+                    std::string announcements_table, 
+                    std::string results_table,
+                    std::string full_path_results_table,
+                    int exclude_as_number,
+                    std::string config_section) 
+: SQLQuerier(announcements_table, results_table, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, full_path_results_table, exclude_as_number, config_section) {
     this->policy_tables = policy_tables;
 }
 

--- a/src/SQLQueriers/ROVSQLQuerier.cpp
+++ b/src/SQLQueriers/ROVSQLQuerier.cpp
@@ -20,3 +20,21 @@ pqxx::result ROVSQLQuerier::select_AS_flags(std::string const& policy_table){
     std::string sql = "SELECT asn, as_type, impliment FROM " + policy_table + ";";
     return execute(sql);
 }
+
+/** Pulls all announcements for the announcements for the given prefix.
+ *
+ * @param p The prefix for which we SELECT
+ */
+pqxx::result ROVSQLQuerier::select_prefix_ann(Prefix<>* p) {
+    std::string sql = select_prefix_query_string(p, false, "host(prefix), netmask(prefix), as_path, origin, time, roa_validity");
+    return execute(sql);
+}
+
+/** Pulls all announcements for the prefixes contained within the passed subnet.
+ *
+ * @param p The prefix defining the subnet
+ */
+pqxx::result ROVSQLQuerier::select_subnet_ann(Prefix<>* p) {
+    std::string sql = select_prefix_query_string(p, true, "host(prefix), netmask(prefix), as_path, origin, time, roa_validity");
+    return execute(sql);
+}

--- a/src/Tests/ROVTests.cpp
+++ b/src/Tests/ROVTests.cpp
@@ -1,0 +1,710 @@
+#include "Tests/Tests.h"
+#include "Extrapolators/ROVExtrapolator.h"
+
+/** ROVExtrapolator tests, copied mostly from ROVppTests.cpp 
+ */
+
+
+bool test_rov_constructor() {
+    ROVExtrapolator e = ROVExtrapolator();
+    if (e.graph == NULL) { return false; }
+    return true;
+}
+
+/** Test is_from_attacker which should return false if the origin of the announcement is an
+ *  attacker. 
+ *
+ * @return True if successful, otherwise false
+ */
+bool test_rov_is_from_attacker() {
+    ROVASGraph graph = ROVASGraph();
+    graph.add_relationship(1, 2, AS_REL_PROVIDER);
+    graph.add_relationship(2, 1, AS_REL_CUSTOMER);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    ROVAnnouncement ann = ROVAnnouncement(13796, p.addr, p.netmask, 22742);
+
+    // No attackers
+    if (graph.ases->find(1)->second->is_from_attacker(ann) == true) {
+        return false;
+    }
+
+    // Origin is not an attacker
+    graph.add_attacker(666);
+    if (graph.ases->find(1)->second->is_from_attacker(ann) == true) {
+        return false;
+    }
+
+    // Origin is an attacker
+    graph.add_attacker(13796);
+    if (graph.ases->find(1)->second->is_from_attacker(ann) == false) {
+        return false;
+    }
+    return true;
+}
+
+/** Test is_attacker which should return true if the AS is an attacker. 
+ *
+ * @return True if successful, otherwise false
+ */
+bool test_rov_is_attacker() {
+    std::set<uint32_t> attackers;
+    attackers.insert(1);
+    ROVAS as = ROVAS(1, &attackers);
+
+    return as.is_attacker();
+}
+
+/** Test directly adding an announcement to an AS.
+ *
+ * @return true if successful.
+ */
+bool test_rov_process_announcement(){
+    ROVAnnouncement ann = ROVAnnouncement(13796, 0x89630000, 0xFFFF0000, 22742);
+    ROVASGraph graph = ROVASGraph();
+    ROVAS as = *graph.createNew(1);
+    // this function should make a copy of the announcement
+    // if it does not, it is incorrect
+    as.process_announcement(ann);
+    Prefix<> old_prefix = ann.prefix;
+    ann.prefix.addr = 0x321C9F00;
+    ann.prefix.netmask = 0xFFFFFF00;
+    Prefix<> new_prefix = ann.prefix;
+    as.process_announcement(ann);
+    if (new_prefix != as.all_anns->find(ann.prefix)->second.prefix ||
+        old_prefix != as.all_anns->find(old_prefix)->second.prefix) {
+        return false;
+    }
+
+    // When an AS adopts ROV, an announcement should be processed when it's not from an attacker
+    graph.add_attacker(535);
+    as.set_rov_adoption(true);
+    as.all_anns->clear();
+    as.process_announcement(ann);
+    if (as.all_anns->size() != 1) {
+        std::cerr << "Failed process announcement, adopts ROV, good announcement" << std::endl;
+        return false;
+    }
+
+    // When an AS doesn't adopt ROV, an announcement should be processed at all times
+    // Set ann's origin to an attacker
+    ann.origin = 535;
+    as.set_rov_adoption(false);
+    as.all_anns->clear();
+    as.process_announcement(ann);
+    if (as.all_anns->size() != 1) {
+        std::cerr << "Failed process announcement, doesn't adopt ROV" << std::endl;
+        return false;
+    }
+
+    // When an AS is an attacker, an announcement should be processed at all times
+    // Even if an AS adopts ROV
+    as.asn = 535;
+    as.set_rov_adoption(true);
+    as.all_anns->clear();
+    as.process_announcement(ann);
+    if (as.all_anns->size() != 1) {
+        std::cerr << "Failed process announcement, attacker" << std::endl;
+        return false;
+    }
+
+    // Don't need to check priority or new best annoucement here because it uses parent's function
+    return true;
+}
+
+/** Test seeding the graph with announcements from monitors. 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  The test path vect is [3, 2, 5]. 
+ */
+bool test_rov_give_ann_to_as_path() {
+    ROVExtrapolator e = ROVExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2);
+
+    // Test that monitor annoucements were received
+    if(!(e.graph->ases->find(2)->second->all_anns->find(p)->second.from_monitor &&
+         e.graph->ases->find(3)->second->all_anns->find(p)->second.from_monitor &&
+         e.graph->ases->find(5)->second->all_anns->find(p)->second.from_monitor)) {
+        std::cerr << "Monitor flag failed." << std::endl;
+        delete as_path;
+        return false;
+    }
+
+    // Test announcement priority calculation
+    if (e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400) {
+        std::cerr << "Priority calculation failed." << std::endl;
+        delete as_path;
+        return false;
+    }
+
+    // Test that only path received the announcement
+    if (!(e.graph->ases->find(1)->second->all_anns->size() == 0 &&
+        e.graph->ases->find(2)->second->all_anns->size() == 1 &&
+        e.graph->ases->find(3)->second->all_anns->size() == 1 &&
+        e.graph->ases->find(4)->second->all_anns->size() == 0 &&
+        e.graph->ases->find(5)->second->all_anns->size() == 1 &&
+        e.graph->ases->find(6)->second->all_anns->size() == 0)) {
+        std::cerr << "MRT overseeding check failed." << std::endl;
+        delete as_path;
+        return false;
+    }
+
+    // Test timestamp tie breaking
+    std::vector<uint32_t> *as_path_b = new std::vector<uint32_t>();
+    as_path_b->push_back(1);
+    as_path_b->push_back(2);
+    as_path_b->push_back(4);
+    as_path_b->push_back(4);
+    e.give_ann_to_as_path(as_path_b, p, 1);
+
+    if (e.graph->ases->find(2)->second->all_anns->find(p)->second.tstamp != 1) {
+        delete as_path;
+        delete as_path_b;
+        return false;
+    }
+    
+    // Test prepending calculation
+    if (e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 298) {
+        std::cout << e.graph->ases->find(2)->second->all_anns->find(p)->second.priority << std::endl;
+        delete as_path;
+        delete as_path_b;
+        return false;
+    }
+
+    delete as_path;
+    delete as_path_b;
+    return true;
+}
+
+/** Test seeding the graph with announcements from monitors with a ROA invalid path. 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  The test path vect is [3, 2, 5]. 
+ */
+bool test_rov_give_ann_to_as_path_invalid() {
+    ROVExtrapolator e = ROVExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    // Set ROV adoption manually (normally set in ROVASGraph::create_graph_from_db)
+    e.graph->ases->find(3)->second->set_rov_adoption(true);
+    e.graph->ases->find(2)->second->set_rov_adoption(true);
+    e.graph->ases->find(5)->second->set_rov_adoption(true);
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 2);
+
+    // Test that only path received the announcement
+    if (!(e.graph->ases->find(1)->second->all_anns->size() == 0 &&
+        e.graph->ases->find(2)->second->all_anns->size() == 0 &&
+        e.graph->ases->find(3)->second->all_anns->size() == 0 &&
+        e.graph->ases->find(4)->second->all_anns->size() == 0 &&
+        e.graph->ases->find(5)->second->all_anns->size() == 1 &&
+        e.graph->ases->find(6)->second->all_anns->size() == 0)) {
+        std::cerr << "MRT overseeding check failed." << std::endl;
+        delete as_path;
+        return false;
+    }
+
+    // Test that monitor annoucements were received
+    if (!e.graph->ases->find(5)->second->all_anns->find(p)->second.from_monitor) {
+        std::cerr << "Monitor flag failed." << std::endl;
+        delete as_path;
+        return false;
+    }
+
+    // Test announcement priority calculation
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400) {
+        std::cerr << "Priority calculation failed." << std::endl;
+        delete as_path;
+        return false;
+    }
+
+    delete as_path;
+    return true;
+}
+
+/** Test send_all_announcements in the following test graph.
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2---3
+ *   /|    \
+ *  4 5--6  7
+ *
+ *  Starting propagation at 5, only 4 and 7 should not see the announcement.
+ */
+bool test_rov_send_all_announcements() {
+    ROVExtrapolator e = ROVExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(7, 3, AS_REL_PROVIDER);
+    e.graph->add_relationship(3, 7, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(2);
+    as_path->push_back(4);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 0);
+    delete as_path;
+
+    // Check to providers
+    e.send_all_announcements(2, true, false, false);
+    if (!(e.graph->ases->find(1)->second->incoming_announcements->size() == 1 &&
+          e.graph->ases->find(2)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(3)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(4)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(5)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(6)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(7)->second->incoming_announcements->size() == 0)) {
+        std::cerr << "Error sending to providers" << std::endl;
+        return false;
+    }
+    
+    // Check to peers
+    e.send_all_announcements(2, false, true, false);
+    if (!(e.graph->ases->find(1)->second->incoming_announcements->size() == 1 &&
+          e.graph->ases->find(2)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(3)->second->incoming_announcements->size() == 1 &&
+          e.graph->ases->find(4)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(5)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(6)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(7)->second->incoming_announcements->size() == 0)) {
+        std::cerr << "Error sending to peers" << std::endl;
+        return false;
+    }
+
+    // Check to customers
+    e.send_all_announcements(2, false, false, true);
+    if (!(e.graph->ases->find(1)->second->incoming_announcements->size() == 1 &&
+          e.graph->ases->find(2)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(3)->second->incoming_announcements->size() == 1 &&
+          e.graph->ases->find(4)->second->incoming_announcements->size() == 1 &&
+          e.graph->ases->find(5)->second->incoming_announcements->size() == 1 &&
+          e.graph->ases->find(6)->second->incoming_announcements->size() == 0 &&
+          e.graph->ases->find(7)->second->incoming_announcements->size() == 0)) {
+        std::cerr << "Error sending to customers" << std::endl;
+        return false;
+    }
+
+    // Process announcements to get the correct announcement priority
+    e.graph->ases->find(1)->second->process_announcements(true);
+    e.graph->ases->find(2)->second->process_announcements(true);
+    e.graph->ases->find(3)->second->process_announcements(true);
+    e.graph->ases->find(4)->second->process_announcements(true);
+    e.graph->ases->find(5)->second->process_announcements(true);
+
+    // Check priority calculation
+    if (e.graph->ases->find(4)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(1)->second->all_anns->find(p)->second.priority != 298 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198 ||
+        e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 98) {
+        std::cerr << "Send all announcements priority calculation failed." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 3, 2, 5]. This shouldn't change the priority since prepending is in the back of the path. 
+ */
+bool test_rov_prepending_priority_back() {
+    ROVExtrapolator e = ROVExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "rov_prepending_priority_back failed." << std::endl;
+        delete as_path;
+        return false;
+    }
+    delete as_path;
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 2, 5]. This should reduce the priority at 3. 
+ */
+bool test_rov_prepending_priority_middle() {
+    ROVExtrapolator e = ROVExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 197) {
+        std::cerr << "rov_prepending_priority_middle failed." << std::endl;
+        delete as_path;
+        return false;
+    }
+    delete as_path;
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 5, 5]. This should reduce the priority at 3 and 5. 
+ */
+bool test_rov_prepending_priority_beginning() {
+    ROVExtrapolator e = ROVExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 298 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 197) {
+        std::cerr << "rov_prepending_priority_end failed." << std::endl;
+        delete as_path;
+        return false;
+    }
+    delete as_path;
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 3, 2, 5] with an existing announcement at those ASes. This shouldn't change the priority since prepending is in the back of the path.  
+ */
+bool test_rov_prepending_priority_back_existing_ann() {
+    ROVExtrapolator e = ROVExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+
+    std::vector<uint32_t> *as_path_b = new std::vector<uint32_t>();
+    as_path_b->push_back(3);
+    as_path_b->push_back(3);
+    as_path_b->push_back(2);
+    as_path_b->push_back(5);
+    e.give_ann_to_as_path(as_path_b, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "rov_prepending_priority_back_existing_ann failed." << std::endl;
+        delete as_path;
+        delete as_path_b;
+        return false;
+    }
+    delete as_path;
+    delete as_path_b;
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 2, 5] with an existing announcement at those ASes. This shouldn't change the priority since the existing announcement has higher priority.  
+ */
+bool test_rov_prepending_priority_middle_existing_ann() {
+    ROVExtrapolator e = ROVExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+    
+    std::vector<uint32_t> *as_path_b = new std::vector<uint32_t>();
+    as_path_b->push_back(3);
+    as_path_b->push_back(2);
+    as_path_b->push_back(2);
+    as_path_b->push_back(5);
+    e.give_ann_to_as_path(as_path_b, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "rov_prepending_priority_middle_existing_ann failed." << std::endl;
+        delete as_path;
+        delete as_path_b;
+        return false;
+    }
+    delete as_path;
+    delete as_path_b;
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 5, 5] with an existing announcement at those ASes. This shouldn't change the priority since the existing announcement has higher priority.  
+ */
+bool test_rov_prepending_priority_beginning_existing_ann() {
+    ROVExtrapolator e = ROVExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+
+    std::vector<uint32_t> *as_path_b = new std::vector<uint32_t>();
+    as_path_b->push_back(3);
+    as_path_b->push_back(2);
+    as_path_b->push_back(5);
+    as_path_b->push_back(5);
+    e.give_ann_to_as_path(as_path_b, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "rov_prepending_priority_beginning_existing_ann failed." << std::endl;
+        delete as_path;
+        delete as_path_b;
+        return false;
+    }
+    delete as_path;
+    delete as_path_b;
+    return true;
+}
+
+/** 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *    |
+ *    2--3
+ *   /|   
+ *  4 5--6 
+ *
+ *  Test prepending on path vector [3, 2, 5, 5] with an existing announcement at those ASes. This should change the priority since the existing announcement has lower priority.  
+ */
+bool test_rov_prepending_priority_beginning_existing_ann2() {
+    ROVExtrapolator e = ROVExtrapolator();
+    e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
+    e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
+    e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 5, AS_REL_CUSTOMER);
+    e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
+    e.graph->add_relationship(2, 4, AS_REL_CUSTOMER);
+    e.graph->add_relationship(2, 3, AS_REL_PEER);
+    e.graph->add_relationship(3, 2, AS_REL_PEER);
+    e.graph->add_relationship(5, 6, AS_REL_PEER);
+    e.graph->add_relationship(6, 5, AS_REL_PEER);
+    e.graph->decide_ranks();
+
+    std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
+    as_path->push_back(3);
+    as_path->push_back(2);
+    as_path->push_back(5);
+    as_path->push_back(5);
+    Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
+    e.give_ann_to_as_path(as_path, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 298 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 197) {
+        std::cerr << "rov_prepending_priority_beginning_existing_ann2 failed." << std::endl;
+        delete as_path;
+        return false;
+    }
+
+    std::vector<uint32_t> *as_path_b = new std::vector<uint32_t>();
+    as_path_b->push_back(3);
+    as_path_b->push_back(2);
+    as_path_b->push_back(5);
+    e.give_ann_to_as_path(as_path_b, p, 2, 0);
+
+    if (e.graph->ases->find(5)->second->all_anns->find(p)->second.priority != 400 ||
+        e.graph->ases->find(2)->second->all_anns->find(p)->second.priority != 299 ||
+        e.graph->ases->find(3)->second->all_anns->find(p)->second.priority != 198) {
+        std::cerr << "rov_prepending_priority_beginning_existing_ann2 failed." << std::endl;
+        delete as_path;
+        delete as_path_b;
+        return false;
+    }
+    delete as_path;
+    delete as_path_b;
+    return true;
+}

--- a/src/Tests/Tests.cpp
+++ b/src/Tests/Tests.cpp
@@ -300,8 +300,51 @@ BOOST_AUTO_TEST_CASE( ROVpp_prepending_priority_beginning_existing_ann2 ) {
         BOOST_CHECK( test_rovpp_prepending_priority_beginning_existing_ann2() );
 }
 
-//EZBGPsec Tests
+//ROV Tests
+BOOST_AUTO_TEST_CASE( ROV_constructor ) {
+        BOOST_CHECK( test_rov_constructor() );
+}
+BOOST_AUTO_TEST_CASE( ROV_is_attacker ) {
+        BOOST_CHECK( test_rov_is_attacker() );
+}
+BOOST_AUTO_TEST_CASE( ROV_is_from_attacker ) {
+        BOOST_CHECK( test_rov_is_from_attacker() );
+}
+BOOST_AUTO_TEST_CASE( ROV_give_ann_to_as_path ) {
+        BOOST_CHECK( test_rov_give_ann_to_as_path() );
+}
+BOOST_AUTO_TEST_CASE( ROV_give_ann_to_as_path_invalid ) {
+        BOOST_CHECK( test_rov_give_ann_to_as_path_invalid() );
+}
+BOOST_AUTO_TEST_CASE( ROV_send_all_announcements ) {
+        BOOST_CHECK( test_rov_send_all_announcements() );
+}
+BOOST_AUTO_TEST_CASE( ROV_process_announcement ) {
+        BOOST_CHECK( test_rov_process_announcement() );
+}
+BOOST_AUTO_TEST_CASE( ROV_prepending_priority_back ) {
+        BOOST_CHECK( test_rov_prepending_priority_back() );
+}
+BOOST_AUTO_TEST_CASE( ROV_prepending_priority_middle ) {
+        BOOST_CHECK( test_rov_prepending_priority_middle() );
+}
+BOOST_AUTO_TEST_CASE( ROV_prepending_priority_beginning ) {
+        BOOST_CHECK( test_rov_prepending_priority_beginning() );
+}
+BOOST_AUTO_TEST_CASE( ROV_prepending_priority_back_existing_ann ) {
+        BOOST_CHECK( test_rov_prepending_priority_back_existing_ann() );
+}
+BOOST_AUTO_TEST_CASE( ROV_prepending_priority_middle_existing_ann ) {
+        BOOST_CHECK( test_rov_prepending_priority_middle_existing_ann() );
+}
+BOOST_AUTO_TEST_CASE( ROV_prepending_priority_beginning_existing_ann ) {
+        BOOST_CHECK( test_rov_prepending_priority_beginning_existing_ann() );
+}
+BOOST_AUTO_TEST_CASE( ROV_prepending_priority_beginning_existing_ann2 ) {
+        BOOST_CHECK( test_rov_prepending_priority_beginning_existing_ann2() );
+}
 
+//EZBGPsec Tests
 BOOST_AUTO_TEST_CASE( EZBGPsec_test_path_propagation ) {
         BOOST_CHECK( ezbgpsec_test_path_propagation() );
 }


### PR DESCRIPTION
Contains a version of extrapolator that implements ROV. Includes its own child class for Announcement, AS, and every other class.

_ROVppExtrapolator can be used only after reworking `ROVPPAS_TYPE` flags in ROVppAS.h. I changed `ROVPPAS_TYPE_ROV` from 1 to 2 to match lib_bgp_data_.