### PR TITLE
IPv6 Extrapolator support

### DIFF
--- a/include/ASes/AS.h
+++ b/include/ASes/AS.h
@@ -29,9 +29,10 @@
 #include "ASes/BaseAS.h"
 #include "Announcements/Announcement.h"
 
-class AS : public BaseAS<Announcement> {
+template <typename PrefixType = uint32_t>
+class AS : public BaseAS<Announcement<PrefixType>, PrefixType> {
 public:
-    AS(uint32_t asn, bool store_depref_results, std::map<std::pair<Prefix<>, uint32_t>, std::set<uint32_t>*> *inverse_results);
+    AS(uint32_t asn, bool store_depref_results, std::map<std::pair<Prefix<PrefixType>, uint32_t>, std::set<uint32_t>*> *inverse_results);
     AS(uint32_t asn, bool store_depref_results);
     AS(uint32_t asn);
     AS();

--- a/include/ASes/BaseAS.h
+++ b/include/ASes/BaseAS.h
@@ -47,7 +47,6 @@ template <class AnnouncementType, typename PrefixType = uint32_t>
 class BaseAS {
 
 //Ensure that the Announcement class passed in through the template extends the Announcement class.
-//static_assert(std::is_base_of<Announcement<>, AnnouncementType>::value, "AnnouncementType must inherit from Announcement");
 static_assert(std::is_base_of<Announcement<PrefixType>, AnnouncementType>::value, "AnnouncementType must inherit from Announcement");
 
 public:

--- a/include/ASes/BaseAS.h
+++ b/include/ASes/BaseAS.h
@@ -43,11 +43,12 @@
 #include "Announcements/EZAnnouncement.h"
 #include "Announcements/ROVppAnnouncement.h"
 
-template <class AnnouncementType>
+template <class AnnouncementType, typename PrefixType = uint32_t>
 class BaseAS {
 
 //Ensure that the Announcement class passed in through the template extends the Announcement class.
-static_assert(std::is_base_of<Announcement, AnnouncementType>::value, "AnnouncementType must inherit from Announcement");
+//static_assert(std::is_base_of<Announcement<>, AnnouncementType>::value, "AnnouncementType must inherit from Announcement");
+static_assert(std::is_base_of<Announcement<PrefixType>, AnnouncementType>::value, "AnnouncementType must inherit from Announcement");
 
 public:
     uint32_t asn;       // Autonomous System Number
@@ -56,14 +57,14 @@ public:
     // Defer processing of incoming announcements for efficiency
     std::vector<AnnouncementType> *incoming_announcements;
     // Maps of all announcements stored
-    std::map<Prefix<>, AnnouncementType> *all_anns;
-    std::map<Prefix<>, AnnouncementType> *depref_anns;
+    std::map<Prefix<PrefixType>, AnnouncementType> *all_anns;
+    std::map<Prefix<PrefixType>, AnnouncementType> *depref_anns;
     // Stores AS Relationships
     std::set<uint32_t> *providers; 
     std::set<uint32_t> *peers; 
     std::set<uint32_t> *customers; 
     // Pointer to inverted results map for efficiency
-    std::map<std::pair<Prefix<>, uint32_t>,std::set<uint32_t>*> *inverse_results; 
+    std::map<std::pair<Prefix<PrefixType>, uint32_t>,std::set<uint32_t>*> *inverse_results; 
     // If this AS represents multiple ASes, it's "members" are listed here (Supernodes)
     std::vector<uint32_t> *member_ases;
     // Assigned and used in Tarjan's algorithm
@@ -72,7 +73,7 @@ public:
     bool onStack;
     
     // Constructor. Must be in header file.... We like C++ class templates. We like C++ class templates....
-    BaseAS(uint32_t asn, bool store_depref_results, std::map<std::pair<Prefix<>, uint32_t>, std::set<uint32_t>*> *inverse_results) {
+    BaseAS(uint32_t asn, bool store_depref_results, std::map<std::pair<Prefix<PrefixType>, uint32_t>, std::set<uint32_t>*> *inverse_results) {
 
         // Set ASN
         this->asn = asn;
@@ -87,10 +88,10 @@ public:
         this->inverse_results = inverse_results;    // Inverted results map
         member_ases = new std::vector<uint32_t>();    // Supernode members
         incoming_announcements = new std::vector<AnnouncementType>();
-        all_anns = new std::map<Prefix<>, AnnouncementType>();
+        all_anns = new std::map<Prefix<PrefixType>, AnnouncementType>();
 
         if(store_depref_results)
-            depref_anns = new std::map<Prefix<>, AnnouncementType>();
+            depref_anns = new std::map<Prefix<PrefixType>, AnnouncementType>();
         else
             depref_anns = NULL;
 
@@ -136,8 +137,8 @@ public:
      * @param old The prefix/origin to be inserted
      * @param current The prefix/origin to be removed
      */
-    virtual void swap_inverse_result(std::pair<Prefix<>,uint32_t> old, 
-                                        std::pair<Prefix<>,uint32_t> current);
+    virtual void swap_inverse_result(std::pair<Prefix<PrefixType>, uint32_t> old, 
+                                        std::pair<Prefix<PrefixType>, uint32_t> current);
 
     /** Push the incoming propagated announcements to the incoming_announcements vector.
      *
@@ -177,7 +178,7 @@ public:
 
     /** Deletes the announcement of given prefix.
     */
-    virtual void delete_ann(Prefix<> &prefix);
+    virtual void delete_ann(Prefix<PrefixType> &prefix);
 
     //****************** FILE I/O ******************//
 

--- a/include/Announcements/Announcement.h
+++ b/include/Announcements/Announcement.h
@@ -30,9 +30,10 @@
 
 #include "Prefix.h"
 
+template <typename PrefixType = uint32_t>
 class Announcement {
 public:
-    Prefix<> prefix;            // encoded with subnet mask
+    Prefix<PrefixType> prefix;            // encoded with subnet mask
     uint32_t origin;            // origin ASN
     uint32_t priority;          // priority assigned based upon path
     uint32_t received_from_asn; // ASN that sent the ann
@@ -43,17 +44,17 @@ public:
 
     /** Default constructor
      */
-    Announcement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask,
+    Announcement(uint32_t aorigin, PrefixType aprefix, PrefixType anetmask,
         uint32_t from_asn, int64_t timestamp = 0);
     
     /** Priority constructor
      */
-    Announcement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask,
+    Announcement(uint32_t aorigin, PrefixType aprefix, PrefixType anetmask,
         uint32_t pr, uint32_t from_asn, int64_t timestamp, bool a_from_monitor = false);
 
     /** Copy constructor
      */
-    Announcement(const Announcement& ann);
+    Announcement(const Announcement<PrefixType>& ann);
 
     //****************** FILE I/O ******************//
 
@@ -65,7 +66,7 @@ public:
      * @param ann Specifies the announcement from which data is pulled.
      * @return The output stream parameter for reuse/recursion.
      */ 
-    friend std::ostream& operator<<(std::ostream &os, const Announcement& ann);
+    friend std::ostream& operator<<(std::ostream &os, const Announcement<PrefixType>& ann);
 
     /** Passes the announcement struct data to an output stream to csv generation.
      *

--- a/include/Announcements/Announcement.h
+++ b/include/Announcements/Announcement.h
@@ -30,7 +30,11 @@
 
 #include "Prefix.h"
 
-template <typename PrefixType = uint32_t>
+template <typename PrefixType = uint32_t> class Announcement;
+
+template <typename PrefixType = uint32_t> 
+std::ostream& operator<<(std::ostream &os, const Announcement<PrefixType>& ann);
+template <typename PrefixType>
 class Announcement {
 public:
     Prefix<PrefixType> prefix;            // encoded with subnet mask
@@ -66,7 +70,7 @@ public:
      * @param ann Specifies the announcement from which data is pulled.
      * @return The output stream parameter for reuse/recursion.
      */ 
-    friend std::ostream& operator<<(std::ostream &os, const Announcement<PrefixType>& ann);
+    friend std::ostream& operator<<<> (std::ostream &os, const Announcement<PrefixType>& ann);
 
     /** Passes the announcement struct data to an output stream to csv generation.
      *
@@ -75,4 +79,5 @@ public:
      */ 
     virtual std::ostream& to_csv(std::ostream &os);
 };
+
 #endif

--- a/include/Announcements/EZAnnouncement.h
+++ b/include/Announcements/EZAnnouncement.h
@@ -3,7 +3,7 @@
 
 #include "Announcements/Announcement.h"
 
-class EZAnnouncement : public Announcement {
+class EZAnnouncement : public Announcement<> {
 public:
     std::vector<uint32_t> as_path;
     bool from_attacker;

--- a/include/Announcements/ROVppAnnouncement.h
+++ b/include/Announcements/ROVppAnnouncement.h
@@ -26,7 +26,7 @@
 
 #include "Announcements/Announcement.h"
 
-class ROVppAnnouncement : public Announcement {
+class ROVppAnnouncement : public Announcement<> {
 public:
     uint32_t alt;               // flag meaning a "hole" along the path
     uint32_t tiebreak_override; // ensure tiebreaks propagate where they should

--- a/include/Extrapolators/BaseExtrapolator.h
+++ b/include/Extrapolators/BaseExtrapolator.h
@@ -30,6 +30,7 @@
 #define DEFAULT_STORE_DEPREF_RESULTS false
 
 #define DEFAULT_ORIGIN_ONLY false
+#define DEFAULT_IPV6_MODE false
 
 #include <vector>
 #include <bits/stdc++.h>

--- a/include/Extrapolators/BlockedExtrapolator.h
+++ b/include/Extrapolators/BlockedExtrapolator.h
@@ -6,7 +6,7 @@
 
 #include "Extrapolators/BaseExtrapolator.h"
 
-template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
+template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType, typename PrefixType = uint32_t>
 class BlockedExtrapolator : public BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>  {
 protected:
     uint32_t iteration_size;
@@ -22,7 +22,7 @@ protected:
      *  Overrwritable function that is called after populate_blocks in the preform_propagation function.
      *  Purely here for inheritance reasons.
      */
-    virtual void extrapolate(std::vector<Prefix<>*> *prefix_blocks, std::vector<Prefix<>*> *subnet_blocks);
+    virtual void extrapolate(std::vector<Prefix<PrefixType>*> *prefix_blocks, std::vector<Prefix<PrefixType>*> *subnet_blocks);
 
 public:
     BlockedExtrapolator(bool random_tiebraking,
@@ -54,16 +54,16 @@ public:
      * @param p The current subnet for checking announcement block size
      * @param prefix_vector The vector of prefixes of appropriate size
      */
-    virtual void populate_blocks(Prefix<>*, 
-                                    std::vector<Prefix<>*>*, 
-                                    std::vector<Prefix<>*>*);
+    virtual void populate_blocks(Prefix<PrefixType>*, 
+                                    std::vector<Prefix<PrefixType>*>*, 
+                                    std::vector<Prefix<PrefixType>*>*);
 
     /** Process a set of prefix or subnet blocks in iterations.
     */
     virtual void extrapolate_blocks(uint32_t &announcement_count, 
                                     int &iteration, 
                                     bool subnet, 
-                                    std::vector<Prefix<>*> *prefix_set);
+                                    std::vector<Prefix<PrefixType>*> *prefix_set);
 
     /** Seed announcement on all ASes on as_path. 
      *
@@ -75,7 +75,7 @@ public:
      * @param as_path Vector of ASNs for this announcement.
      * @param prefix The prefix this announcement is for.
      */
-    virtual void give_ann_to_as_path(std::vector<uint32_t>* as_path, Prefix<> prefix, int64_t timestamp = 0);
+    virtual void give_ann_to_as_path(std::vector<uint32_t>* as_path, Prefix<PrefixType> prefix, int64_t timestamp = 0);
 
     /** Send all announcements kept by an AS to its neighbors. 
      *

--- a/include/Extrapolators/Extrapolator.h
+++ b/include/Extrapolators/Extrapolator.h
@@ -29,25 +29,7 @@
 template <typename PrefixType = uint32_t>
 class Extrapolator : public BlockedExtrapolator<SQLQuerier<PrefixType>, ASGraph<PrefixType>, Announcement<PrefixType>, AS<PrefixType>, PrefixType> {
 public:
-    Extrapolator() : Extrapolator<PrefixType>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE,
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, DEFAULT_MH_MODE, DEFAULT_ORIGIN_ONLY, NULL) { };
-
-    // Extrapolator(bool random_tiebraking,
-    //                 bool store_results, 
-    //                 bool store_invert_results, 
-    //                 bool store_depref_results, 
-    //                 std::string announcement_table,
-    //                 std::string results_table, 
-    //                 std::string inverse_results_table, 
-    //                 std::string depref_results_table,
-    //                 std::string full_path_results_table,
-    //                 std::string config_section, 
-    //                 uint32_t iteration_size,
-    //                 int exclude_as_number,
-    //                 uint32_t mh_mode,
-    //                 bool origin_only,
-    //                 std::vector<uint32_t> *full_path_asns);
+    Extrapolator();
 
     Extrapolator(bool random_tiebraking,
                     bool store_results, 
@@ -63,14 +45,9 @@ public:
                     int exclude_as_number,
                     uint32_t mh_mode,
                     bool origin_only,
-                    std::vector<uint32_t> *full_path_asns) : 
-                    BlockedExtrapolator<SQLQuerier<PrefixType>, ASGraph<PrefixType>, Announcement<PrefixType>, AS<PrefixType>, PrefixType>
-                    (random_tiebraking, store_results, store_invert_results, store_depref_results, iteration_size, mh_mode, origin_only, full_path_asns) {
+                    std::vector<uint32_t> *full_path_asns);
 
-    this->graph = new ASGraph<PrefixType>(store_invert_results, store_depref_results);
-    this->querier = new SQLQuerier<PrefixType>
-    (announcement_table, results_table, inverse_results_table, depref_results_table, full_path_results_table, exclude_as_number, config_section);
-};
+    
 
     virtual ~Extrapolator();
 };

--- a/include/Extrapolators/Extrapolator.h
+++ b/include/Extrapolators/Extrapolator.h
@@ -29,8 +29,6 @@
 template <typename PrefixType = uint32_t>
 class Extrapolator : public BlockedExtrapolator<SQLQuerier<PrefixType>, ASGraph<PrefixType>, Announcement<PrefixType>, AS<PrefixType>, PrefixType> {
 public:
-    Extrapolator();
-
     Extrapolator(bool random_tiebraking,
                     bool store_results, 
                     bool store_invert_results, 
@@ -47,9 +45,8 @@ public:
                     bool origin_only,
                     std::vector<uint32_t> *full_path_asns);
 
-    
-
-    virtual ~Extrapolator();
+    Extrapolator();
+    ~Extrapolator();
 };
 
 #endif

--- a/include/Extrapolators/Extrapolator.h
+++ b/include/Extrapolators/Extrapolator.h
@@ -27,9 +27,27 @@
 #include "Extrapolators/BlockedExtrapolator.h"
 
 template <typename PrefixType = uint32_t>
-class Extrapolator : public BlockedExtrapolator<SQLQuerier, ASGraph<PrefixType>, Announcement<PrefixType>, AS<PrefixType>, Prefix<PrefixType>> {
+class Extrapolator : public BlockedExtrapolator<SQLQuerier<PrefixType>, ASGraph<PrefixType>, Announcement<PrefixType>, AS<PrefixType>, PrefixType> {
 public:
-    Extrapolator();
+    Extrapolator() : Extrapolator<PrefixType>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE,
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, DEFAULT_MH_MODE, DEFAULT_ORIGIN_ONLY, NULL) { };
+
+    // Extrapolator(bool random_tiebraking,
+    //                 bool store_results, 
+    //                 bool store_invert_results, 
+    //                 bool store_depref_results, 
+    //                 std::string announcement_table,
+    //                 std::string results_table, 
+    //                 std::string inverse_results_table, 
+    //                 std::string depref_results_table,
+    //                 std::string full_path_results_table,
+    //                 std::string config_section, 
+    //                 uint32_t iteration_size,
+    //                 int exclude_as_number,
+    //                 uint32_t mh_mode,
+    //                 bool origin_only,
+    //                 std::vector<uint32_t> *full_path_asns);
 
     Extrapolator(bool random_tiebraking,
                     bool store_results, 
@@ -45,7 +63,14 @@ public:
                     int exclude_as_number,
                     uint32_t mh_mode,
                     bool origin_only,
-                    std::vector<uint32_t> *full_path_asns);
+                    std::vector<uint32_t> *full_path_asns) : 
+                    BlockedExtrapolator<SQLQuerier<PrefixType>, ASGraph<PrefixType>, Announcement<PrefixType>, AS<PrefixType>, PrefixType>
+                    (random_tiebraking, store_results, store_invert_results, store_depref_results, iteration_size, mh_mode, origin_only, full_path_asns) {
+
+    this->graph = new ASGraph<PrefixType>(store_invert_results, store_depref_results);
+    this->querier = new SQLQuerier<PrefixType>
+    (announcement_table, results_table, inverse_results_table, depref_results_table, full_path_results_table, exclude_as_number, config_section);
+};
 
     virtual ~Extrapolator();
 };

--- a/include/Extrapolators/Extrapolator.h
+++ b/include/Extrapolators/Extrapolator.h
@@ -26,8 +26,11 @@
 
 #include "Extrapolators/BlockedExtrapolator.h"
 
-class Extrapolator : public BlockedExtrapolator<SQLQuerier, ASGraph, Announcement, AS> {
+template <typename PrefixType = uint32_t>
+class Extrapolator : public BlockedExtrapolator<SQLQuerier, ASGraph<PrefixType>, Announcement<PrefixType>, AS<PrefixType>, Prefix<PrefixType>> {
 public:
+    Extrapolator();
+
     Extrapolator(bool random_tiebraking,
                     bool store_results, 
                     bool store_invert_results, 
@@ -44,8 +47,7 @@ public:
                     bool origin_only,
                     std::vector<uint32_t> *full_path_asns);
 
-    Extrapolator();
-    ~Extrapolator();
+    virtual ~Extrapolator();
 };
 
 #endif

--- a/include/Graphs/ASGraph.h
+++ b/include/Graphs/ASGraph.h
@@ -26,12 +26,13 @@
 
 #include "Graphs/BaseGraph.h"
 
-class ASGraph : public BaseGraph<AS> {
+template <typename PrefixType = uint32_t>
+class ASGraph : public BaseGraph<AS<PrefixType>, PrefixType> {
 public:
     ASGraph(bool store_inverse_results, bool store_depref_results);
     virtual ~ASGraph();
 
-    virtual AS* createNew(uint32_t asn);
+    virtual AS<PrefixType>* createNew(uint32_t asn);
 };
 
 #endif

--- a/include/Graphs/BaseGraph.h
+++ b/include/Graphs/BaseGraph.h
@@ -46,7 +46,7 @@ class SQLQuerier;
 #include "SQLQueriers/SQLQuerier.h"
 #include "TableNames.h"
 
-template <class ASType>
+template <class ASType, typename PrefixType = uint32_t>
 class BaseGraph {
 
 // static_assert(std::is_base_of<BaseAS, ASType>::value, "ASType must inherit from BaseAS");
@@ -59,7 +59,7 @@ public:
     std::map<uint32_t, uint32_t> *component_translation;// Translate AS to supernode AS
     std::map<uint32_t, uint32_t> *stubs_to_parents;
     std::vector<uint32_t> *non_stubs;
-    std::map<std::pair<Prefix<>, uint32_t>,std::set<uint32_t>*> *inverse_results; 
+    std::map<std::pair<Prefix<PrefixType>, uint32_t>,std::set<uint32_t>*> *inverse_results; 
 
     bool store_depref_results;
 
@@ -72,7 +72,7 @@ public:
         non_stubs = new std::vector<uint32_t>;                      // All non-stubs in the graph
 
         if(store_inverse_results) 
-            inverse_results = new std::map<std::pair<Prefix<>, uint32_t>, std::set<uint32_t>*>;
+            inverse_results = new std::map<std::pair<Prefix<PrefixType>, uint32_t>, std::set<uint32_t>*>;
         else 
             inverse_results = NULL;
         
@@ -111,7 +111,7 @@ public:
 
     /** Process with removing stubs (needs querier to save them).
     */
-    virtual void process(SQLQuerier *querier);
+    virtual void process(SQLQuerier<PrefixType> *querier);
 
     /** Generates an ASGraph from relationship data in an SQL database based upon:
      *      1) A populated peers table
@@ -119,31 +119,31 @@ public:
      * 
      * @param querier
      */
-    virtual void create_graph_from_db(SQLQuerier *querier);
+    virtual void create_graph_from_db(SQLQuerier<PrefixType> *querier);
 
     /** Remove the stub ASes from the graph.
      *
      * @param querier
      */
-    virtual void remove_stubs(SQLQuerier *querier);
+    virtual void remove_stubs(SQLQuerier<PrefixType> *querier);
 
     /** Saves the stub ASes to be removed to a table on the database.
      *
      * @param querier
      */
-    virtual void save_stubs_to_db(SQLQuerier *querier);
+    virtual void save_stubs_to_db(SQLQuerier<PrefixType> *querier);
 
     /** Saves the non_stub ASes to a table on the database.
      *
      * @param querier
      */
-    virtual void save_non_stubs_to_db(SQLQuerier *querier);
+    virtual void save_non_stubs_to_db(SQLQuerier<PrefixType> *querier);
 
     /** Generate a csv with all supernodes, then dump them to database.
      *
      * @param querier
      */
-    virtual void save_supernodes_to_db(SQLQuerier *querier);
+    virtual void save_supernodes_to_db(SQLQuerier<PrefixType> *querier);
 
     /** Decide and assign ranks to all the AS's in the graph. 
      *

--- a/include/Graphs/BaseGraph.h
+++ b/include/Graphs/BaseGraph.h
@@ -29,8 +29,6 @@
 #define AS_REL_PEER 100
 #define AS_REL_CUSTOMER 200
 
-//class SQLQuerier;
-
 #include <map>
 #include <unordered_map>
 #include <vector>

--- a/include/Graphs/BaseGraph.h
+++ b/include/Graphs/BaseGraph.h
@@ -29,7 +29,7 @@
 #define AS_REL_PEER 100
 #define AS_REL_CUSTOMER 200
 
-class SQLQuerier;
+//class SQLQuerier;
 
 #include <map>
 #include <unordered_map>

--- a/include/Graphs/EZASGraph.h
+++ b/include/Graphs/EZASGraph.h
@@ -22,7 +22,7 @@ public:
     EZAS* createNew(uint32_t asn);
 
     void disconnectAttackerEdges();
-    void distributeAttackersVictims(SQLQuerier* querier);
-    void process(SQLQuerier* querier);
+    void distributeAttackersVictims(SQLQuerier<>* querier);
+    void process(SQLQuerier<>* querier);
 };
 #endif

--- a/include/Graphs/ROVppASGraph.h
+++ b/include/Graphs/ROVppASGraph.h
@@ -46,7 +46,7 @@ public:
 
     /** Process the graph without removing stubs (needs querier to save them).
     */
-    void process(SQLQuerier *querier);
+    void process(SQLQuerier<> *querier);
 
     /** Generates an ASGraph from relationship data in an SQL database based upon:
      *      1) A populated peers table

--- a/include/Graphs/RanGraph.h
+++ b/include/Graphs/RanGraph.h
@@ -31,8 +31,8 @@
 #include "ASes/AS.h"
 #include "Graphs/ASGraph.h"
 
-ASGraph* ran_graph(int, int);
-bool cyclic_util(ASGraph*, int, std::map<uint32_t, bool>*, std::map<uint32_t, bool>*);
-bool is_cyclic(ASGraph*);
+ASGraph<>* ran_graph(int, int);
+bool cyclic_util(ASGraph<>*, int, std::map<uint32_t, bool>*, std::map<uint32_t, bool>*);
+bool is_cyclic(ASGraph<>*);
 
 #endif

--- a/include/Prefix.h
+++ b/include/Prefix.h
@@ -273,7 +273,7 @@ public:
             // Not sure if that is what we are looking for
             uint32_t sz = 0;
             for (int i = 0; i < 128; i++) {
-                if (netmask & (1 << i)) {
+                if (netmask & ((uint128_t) 1 << i)) {
                     sz++;
                 }
             }

--- a/include/Prefix.h
+++ b/include/Prefix.h
@@ -241,7 +241,7 @@ public:
         // Default errors to ::
         if (error_f == true) {
             ipv6_ip_int = 0;
-            std::cout << "Caught malformed IPv6 address: " << addr_str << std::endl;
+            BOOST_LOG_TRIVIAL(error) << "Caught malformed IPv4 address: " << addr_str;
         }
         return ipv6_ip_int;
     }

--- a/include/Prefix.h
+++ b/include/Prefix.h
@@ -31,6 +31,7 @@
 
 #include "Logger.h"
 
+typedef unsigned __int128 uint128_t;
 
 // Use uint32_t for IPv4, unsigned __int128 for IPv6
 template <typename Integer = uint32_t>
@@ -63,19 +64,24 @@ public:
      * @param mask_str The subnet mask/length as a string.
      */ 
     Prefix(std::string addr_str, std::string mask_str) {
-        // IPv4 Address Parsing
-        addr = addr_to_int(addr_str);  
-        netmask = mask_to_int(mask_str);  
+        if (std::is_same<Integer, uint128_t>::value) {
+            // IPv6 Address Parsing
+            addr = ipv6_to_int(addr_str);  
+            netmask = ipv6_to_int(mask_str);  
+        } else {
+            // IPv4 Address Parsing
+            addr = ipv4_to_int(addr_str);  
+            netmask = ipv4_to_int(mask_str);  
+        }
     }
     
-    
-    /** Converts a IPv4 address as a string into a integer.
+    /** Converts an IPv4 address or netmask as a string into a integer.
      *
      *  This is IPv4 only.
      *
-     *  @return ipv4_ip_int An integer representation of an address
+     *  @return ipv4_ip_int An integer representation of an address / mask
      */
-    uint32_t addr_to_int(std::string addr_str) const {
+    uint32_t ipv4_to_int(std::string addr_str) const {
         int counter = 0;                // Check for proper addr length
         size_t pos = 0;                 // Position in string addr
         uint32_t ipv4_ip_int = 0;       // Stores the address as an int
@@ -139,42 +145,61 @@ public:
     }
     
     
-    /** Converts a IPv4 netmask as a string into a integer.
+    /** Converts an IPv6 address or netmask as a string into a integer.
      *
-     *  This is IPv4 only.
+     *  This is IPv6 only.
      *
-     *  @return ipv4_mask_int An integer representation of a netmask
+     *  @return ipv6_ip_int An integer representation of an address / mask
      */
-    uint32_t mask_to_int(std::string mask_str) const {
+    uint128_t ipv6_to_int(std::string addr_str) const {
         int counter = 0;                // Check for proper addr length
         size_t pos = 0;                 // Position in string addr
-        uint32_t ipv4_mask_int = 0;     // Stores the netmask as an int
+        uint128_t ipv6_ip_int = 0;       // Stores the address as an int
         std::string token;              // Buffer subseciton of addr
-        std::string delimiter = ".";    // String dilimiter
+        std::string delimiter = ":";    // String dilimiter
         bool error_f = false;           // Error flag, drops malformed input
 
-        std::string s = mask_str;
+        // Create a copy of address string
+        std::string s = addr_str;
         if (s.empty()) {
             error_f = true;
-        } else {
-            while ((pos = s.find(delimiter)) != std::string::npos) { 
+        }
+        else {
+            while ((pos = s.find(delimiter)) != std::string::npos) {
                 // Catch long malformed input
-                if (counter > 3) {
+                if (counter > 7) {
                     error_f = true;
                     break;
                 }
-                // Token is one 8-bit int
+                // Token is one 4-byte int
                 token = s.substr(0, pos);
                 try {
-                    uint32_t token_int = std::stoul(token);
-                    // Catch out of range ints, default to 255
-                    if (token_int > 255) {
+                    // Encountered suppressed zeros
+                    if (token.size() == 0) {
+                        // Calculate the amount of blocks left in s (5 = 4 hex numbers + 1 colon)
+                        int blocks_left = s.size() / 5;
+                        // Calculate the amount of zero blocks suppressed
+                        int zero_blocks = 8 - (counter + blocks_left);
+                        // Shift the result by the amount of bits in zero_blocks
+                        ipv6_ip_int = ipv6_ip_int << (16 * zero_blocks);
+
+                        // Trim token from addr
+                        if (s.size() > 0) {
+                            s.erase(0, pos + delimiter.length());
+                        }
+                        counter += zero_blocks;
+                        continue;
+                    }
+                    uint32_t token_int = std::stoi(token, 0, 16);
+
+                    // Catch out of range ints, default to 65536
+                    if (token_int > 65536) {
                         error_f = true;
                         break;
                     }
-                    // Add token and shift left 8 bits
-                    ipv4_mask_int += std::stoul(token);
-                    ipv4_mask_int = ipv4_mask_int << 8;
+                    // Add token and shift left 16 bits
+                    ipv6_ip_int += token_int;
+                    ipv6_ip_int = ipv6_ip_int << 16;
                     // Trim token from addr
                     s.erase(0, pos + delimiter.length());
                     counter += 1;
@@ -185,28 +210,35 @@ public:
                 }
             }
             // Catch short malformed input
-            if (counter != 3) {
+            if (counter > 7) {
                 error_f = true;
+            } else if (counter < 7) {
+                // If counter < 7, there were multiple suppressed groups of zeros
+                // Shift left by the total amount of bits suppressed
+                ipv6_ip_int = ipv6_ip_int << ((7 - counter) * 16);
             }
-            // Add last 8-bit token
+            // Add the last 16-bit token
             try {
-                uint32_t s_int = std::stoul(s);
-                if (s_int > 255) {
-                    error_f = true;
-                } else {
-                    ipv4_mask_int += s_int;
+                if (s.size() != 0) {
+                    uint32_t s_int = std::stoi(s, 0, 16);
+                    if (s_int > 65536) {
+                        error_f = true;
+                    }
+                    else {
+                        ipv6_ip_int += s_int;
+                    }
                 }
             }
             catch (...) {
                 error_f = true;
             }
         }
-        // Default errors to /0
+        // Default errors to ::
         if (error_f == true) {
-            ipv4_mask_int = 0;
-            BOOST_LOG_TRIVIAL(error) << "Caught malformed IPv4 subnet mask: " << mask_str;
+            ipv6_ip_int = 0;
+            std::cout << "Caught malformed IPv6 address: " << addr_str << std::endl;
         }
-        return ipv4_mask_int;
+        return ipv6_ip_int;
     }
 
 
@@ -217,25 +249,54 @@ public:
      *  @return cidr A string in cidr format.
      */
     std::string to_cidr() const {
-        std::string cidr = "";
-        uint8_t quad = (addr & 0xFF000000) >> 24;
-        cidr.append(std::to_string(quad) + ".");
-        quad = (addr & 0x00FF0000) >> 16;
-        cidr.append(std::to_string(quad) + ".");
-        quad = (addr & 0x0000FF00) >> 8;
-        cidr.append(std::to_string(quad) + ".");
-        quad = (addr & 0x000000FF) >> 0;
-        cidr.append(std::to_string(quad));
-        cidr.push_back('/');
-        // Assume valid cidr netmask, e.g. no ones after the first zero
-        uint8_t sz = 0;
-        for (int i = 0; i < 32; i++) {
-            if (netmask & (1 << i)) {
-                sz++;
+        // Check if this prefix is IPv6 or IPv4
+        if (std::is_same<Integer, uint128_t>::value) {
+            std::ostringstream cidr;
+            for (int i = 112; i >= 0; i = i - 16) {
+                // Process each quad separately
+                int quad = (addr >> i) & 0xFFFF;
+                // Convert quad to hex and add to cidr
+                cidr << std::hex << quad;
+                // Don't add a colon after the last quad
+                if (i != 0) {
+                    cidr << ":";
+                }
             }
+            cidr << '/';
+            
+            // Calculate the number of 1s in netmask
+            // Not sure if that is what we are looking for
+            uint32_t sz = 0;
+            for (int i = 0; i < 128; i++) {
+                if (netmask & (1 << i)) {
+                    sz++;
+                }
+            }
+            // Switch stringstream back to decimal
+            cidr << std::dec << sz;
+            return cidr.str();
+        } else {
+            std::string cidr = "";
+            uint8_t quad = (addr & 0xFF000000) >> 24;
+            cidr.append(std::to_string(quad) + ".");
+            quad = (addr & 0x00FF0000) >> 16;
+            cidr.append(std::to_string(quad) + ".");
+            quad = (addr & 0x0000FF00) >> 8;
+            cidr.append(std::to_string(quad) + ".");
+            quad = (addr & 0x000000FF) >> 0;
+            cidr.append(std::to_string(quad));
+            cidr.push_back('/');
+            // Assume valid cidr netmask, e.g. no ones after the first zero
+            uint8_t sz = 0;
+            for (int i = 0; i < 32; i++) {
+                if (netmask & (1 << i)) {
+                    sz++;
+                }
+            }
+            cidr.append(std::to_string(sz));
+            return cidr;
         }
-        cidr.append(std::to_string(sz));
-        return cidr;
+        return "";
     }
     
 
@@ -246,24 +307,24 @@ public:
      * @param b The Prefix object to which this object is compared.
      * @return true If the operation holds, otherwise false
      */
-    bool operator<(const Prefix &b) const {
-        uint64_t combined = 0;
+    bool operator<(const Prefix<Integer> &b) const {
+        uint128_t combined = 0;
         combined |= addr;
         combined = combined << 32;
         combined |= netmask; 
-        uint64_t combined_b = 0;
+        uint128_t combined_b = 0;
         combined_b |= b.addr;
         combined_b = combined_b << 32;
         combined_b |= b.netmask; 
         return combined < combined_b;
     }
-    bool operator==(const Prefix &b) const {
+    bool operator==(const Prefix<Integer> &b) const {
         return !(*this < b || b < *this);
     }
-    bool operator>(const Prefix &b) const {
+    bool operator>(const Prefix<Integer> &b) const {
         return !(*this < b || *this == b);
     }
-    bool operator!=(const Prefix &b) const {
+    bool operator!=(const Prefix<Integer> &b) const {
         return !(*this == b);
     }
 
@@ -272,7 +333,7 @@ public:
      * @param b The other Prefix.
      * @return true if this prefix is contained in or equal to the other, else false.
      */
-    bool contained_in_or_equal_to(const Prefix &b) const {
+    bool contained_in_or_equal_to(const Prefix<Integer> &b) const {
         return b.netmask <= netmask && (addr & b.netmask) == (b.addr & b.netmask);
     }
 };

--- a/include/Prefix.h
+++ b/include/Prefix.h
@@ -241,15 +241,13 @@ public:
         // Default errors to ::
         if (error_f == true) {
             ipv6_ip_int = 0;
-            BOOST_LOG_TRIVIAL(error) << "Caught malformed IPv4 address: " << addr_str;
+            BOOST_LOG_TRIVIAL(error) << "Caught malformed IPv6 address: " << addr_str;
         }
         return ipv6_ip_int;
     }
 
 
     /** Converts this prefix into a cidr formatted string.
-     *
-     *  This is IPv4 only.
      *
      *  @return cidr A string in cidr format.
      */
@@ -270,7 +268,6 @@ public:
             cidr << '/';
             
             // Calculate the number of 1s in netmask
-            // Not sure if that is what we are looking for
             uint32_t sz = 0;
             for (int i = 0; i < 128; i++) {
                 if (netmask & ((uint128_t) 1 << i)) {

--- a/include/SQLQueriers/EZSQLQuerier.h
+++ b/include/SQLQueriers/EZSQLQuerier.h
@@ -3,7 +3,7 @@
 
 #include "SQLQueriers/SQLQuerier.h"
 
-class EZSQLQuerier : public SQLQuerier {
+class EZSQLQuerier : public SQLQuerier<> {
 public:
     EZSQLQuerier(std::string a=ANNOUNCEMENTS_TABLE, 
                     std::string r=RESULTS_TABLE,

--- a/include/SQLQueriers/ROVppSQLQuerier.h
+++ b/include/SQLQueriers/ROVppSQLQuerier.h
@@ -26,7 +26,7 @@
 
 #include "SQLQueriers/SQLQuerier.h"
 
-class ROVppSQLQuerier: public SQLQuerier {
+class ROVppSQLQuerier: public SQLQuerier<> {
 public:
     std::string simulation_table;
     std::string tracked_ases_table;

--- a/include/SQLQueriers/SQLQuerier.h
+++ b/include/SQLQueriers/SQLQuerier.h
@@ -43,6 +43,7 @@
 #include <boost/program_options.hpp>
 namespace program_options = boost::program_options;
 
+template <typename PrefixType = uint32_t>
 class SQLQuerier {
 public:
     std::string results_table;
@@ -79,10 +80,10 @@ public:
     
     // Select from DB
     pqxx::result select_from_table(std::string table_name, int limit = 0);
-    pqxx::result select_prefix_count(Prefix<>*);
-    virtual pqxx::result select_prefix_ann(Prefix<>*);
-    pqxx::result select_subnet_count(Prefix<>*);
-    virtual pqxx::result select_subnet_ann(Prefix<>*);
+    pqxx::result select_prefix_count(Prefix<PrefixType>*);
+    virtual pqxx::result select_prefix_ann(Prefix<PrefixType>*);
+    pqxx::result select_subnet_count(Prefix<PrefixType>*);
+    virtual pqxx::result select_subnet_ann(Prefix<PrefixType>*);
     
     // Preprocessing Tables
     void clear_stubs_from_db();

--- a/include/SQLQueriers/SQLQuerier.h
+++ b/include/SQLQueriers/SQLQuerier.h
@@ -79,7 +79,7 @@ public:
     pqxx::result execute(std::string sql, bool insert = false);
     
     std::string copy_to_db_query_string(std::string file_name, std::string table_name, std::string column_names);
-    std::string select_prefix_query_string(Prefix<>* p, bool subnet = false, std::string selection = "COUNT(*)");
+    std::string select_prefix_query_string(Prefix<PrefixType>* p, bool subnet = false, std::string selection = "COUNT(*)");
     std::string clear_table_query_string(std::string table_name);
     std::string create_table_query_string(std::string table_name, std::string column_names, bool unlogged = false, std::string grant_all_user = "");
 

--- a/include/Tests/Tests.h
+++ b/include/Tests/Tests.h
@@ -53,11 +53,17 @@
 
 // Prototypes for PrefixTest.cpp
 bool test_prefix();
+bool test_prefix_ipv6();
 bool test_string_to_cidr();
+bool test_string_to_cidr_ipv6();
 bool test_prefix_lt_operator();
+bool test_prefix_lt_operator_ipv6();
 bool test_prefix_gt_operator();
+bool test_prefix_gt_operator_ipv6();
 bool test_prefix_eq_operator();
+bool test_prefix_eq_operator_ipv6();
 bool test_prefix_contained_in_or_equal_to_operator();
+bool test_prefix_contained_in_or_equal_to_operator_ipv6();
 
 // Prototypes for AnnouncementTest.cpp
 bool test_announcement();

--- a/main.cpp
+++ b/main.cpp
@@ -145,6 +145,8 @@ int main(int argc, char *argv[]) {
         exit(0);
     }
 
+    // *** testing *** //
+
     Prefix<> *cur_prefix = new Prefix<>("0.0.0.0", "0.0.0.0");
     std::cout << cur_prefix->to_cidr() << std::endl; 
 
@@ -152,6 +154,8 @@ int main(int argc, char *argv[]) {
     std::cout << cur_prefix->to_cidr() << std::endl;
 
     return 0;
+
+    // *** testing *** //
 
     // Logging
     unsigned int severity_level = vm["severity-level"].as<unsigned int>();
@@ -242,7 +246,7 @@ int main(int argc, char *argv[]) {
         delete extrap;
     } else if (vm["ipv6-mode"].as<bool>()) {
         // Instantiate Extrapolator
-        Extrapolator<Prefix<uint128_t>> *extrap = new Extrapolator<Prefix<uint128_t>> (vm["random"].as<bool>(),
+        Extrapolator<uint128_t> *extrap = new Extrapolator<uint128_t> (vm["random"].as<bool>(),
             vm["store-results"].as<bool>(),
             vm["store-inverse-results"].as<bool>(),
             vm["store-depref"].as<bool>(),

--- a/main.cpp
+++ b/main.cpp
@@ -145,18 +145,6 @@ int main(int argc, char *argv[]) {
         exit(0);
     }
 
-    // *** testing *** //
-
-    Prefix<> *cur_prefix = new Prefix<>("0.0.0.0", "0.0.0.0");
-    std::cout << cur_prefix->to_cidr() << std::endl; 
-
-    cur_prefix = new Prefix<>("192.8.0.1", "255.255.0.0");
-    std::cout << cur_prefix->to_cidr() << std::endl;
-
-    return 0;
-
-    // *** testing *** //
-
     // Logging
     unsigned int severity_level = vm["severity-level"].as<unsigned int>();
     bool log_std_out = vm["log-std-out"].as<bool>();

--- a/main.cpp
+++ b/main.cpp
@@ -263,7 +263,8 @@ int main(int argc, char *argv[]) {
             vm["exclude-monitor"].as<int>(),
             vm["mh-propagation-mode"].as<uint32_t>(),
             vm["origin-only"].as<bool>(),
-            full_path_asns);
+            full_path_asns,
+            vm["max-threads"].as<uint32_t>());
             
         // Run propagation
         extrap->perform_propagation();

--- a/src/ASes/AS.cpp
+++ b/src/ASes/AS.cpp
@@ -1,9 +1,20 @@
 #include "ASes/AS.h"
 
-AS::AS(uint32_t asn, bool store_depref_results, std::map<std::pair<Prefix<>, uint32_t>, std::set<uint32_t>*> *inverse_results) : BaseAS(asn, store_depref_results, inverse_results) { }
-AS::AS(uint32_t asn, bool store_depref_results) : AS(asn, store_depref_results, NULL) { }
-AS::AS(uint32_t asn) : AS(asn, false, NULL) { }
-AS::AS() : AS(0, false, NULL) { }
+template <typename PrefixType>
+AS<PrefixType>::AS(uint32_t asn, bool store_depref_results, std::map<std::pair<Prefix<PrefixType>, uint32_t>, std::set<uint32_t>*> *inverse_results) 
+    : BaseAS<Announcement<PrefixType>, PrefixType>(asn, store_depref_results, inverse_results) { }
 
-AS::~AS() { }
+template <typename PrefixType>
+AS<PrefixType>::AS(uint32_t asn, bool store_depref_results) : AS<PrefixType>(asn, store_depref_results, NULL) { }
 
+template <typename PrefixType>
+AS<PrefixType>::AS(uint32_t asn) : AS<PrefixType>(asn, false, NULL) { }
+
+template <typename PrefixType>
+AS<PrefixType>::AS() : AS<PrefixType>(0, false, NULL) { }
+
+template <typename PrefixType>
+AS<PrefixType>::~AS() { }
+
+template class AS<>;
+template class AS<uint128_t>;

--- a/src/Announcements/Announcement.cpp
+++ b/src/Announcements/Announcement.cpp
@@ -59,8 +59,8 @@ Announcement<PrefixType>::Announcement(const Announcement<PrefixType>& ann) {
 //****************** FILE I/O ******************//
 template <typename PrefixType>
 std::ostream& operator<<(std::ostream &os, const Announcement<PrefixType>& ann) {
-    os << "Prefix:\t\t" << std::hex << ann.prefix.addr << " & " << std::hex << 
-        ann.prefix.netmask << std::endl << "Origin:\t\t" << std::dec << ann.origin
+    os << "Prefix:\t\t" << std::hex << ann.prefix.addr_to_string() << " & " << std::hex << 
+        ann.prefix.netmask_to_string() << std::endl << "Origin:\t\t" << std::dec << ann.origin
         << std::endl << "Priority:\t" << ann.priority << std::endl 
         << "Recv'd from:\t" << std::dec << ann.received_from_asn;
     return os;

--- a/src/Announcements/Announcement.cpp
+++ b/src/Announcements/Announcement.cpp
@@ -23,7 +23,8 @@
 
 #include "Announcements/Announcement.h"
 
-Announcement::Announcement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask,
+template <typename PrefixType>
+Announcement<PrefixType>::Announcement(uint32_t aorigin, PrefixType aprefix, PrefixType anetmask,
     uint32_t from_asn, int64_t timestamp /* = 0 */) {
     
     prefix.addr = aprefix;
@@ -35,7 +36,8 @@ Announcement::Announcement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask
     tstamp = timestamp;
 }
 
-Announcement::Announcement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask,
+template <typename PrefixType>
+Announcement<PrefixType>::Announcement(uint32_t aorigin, PrefixType aprefix, PrefixType anetmask,
     uint32_t pr, uint32_t from_asn, int64_t timestamp, bool a_from_monitor /* = false */) 
     : Announcement(aorigin, aprefix, anetmask, from_asn, timestamp) {
     
@@ -43,7 +45,8 @@ Announcement::Announcement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask
     from_monitor = a_from_monitor;
 }
 
-Announcement::Announcement(const Announcement& ann) {
+template <typename PrefixType>
+Announcement<PrefixType>::Announcement(const Announcement<PrefixType>& ann) {
     prefix = ann.prefix;           
     origin = ann.origin;           
     priority = ann.priority;         
@@ -54,16 +57,19 @@ Announcement::Announcement(const Announcement& ann) {
 }
 
 //****************** FILE I/O ******************//
-
-std::ostream& operator<<(std::ostream &os, const Announcement& ann) {
+template <typename PrefixType>
+std::ostream& operator<<(std::ostream &os, const Announcement<PrefixType>& ann) {
     os << "Prefix:\t\t" << std::hex << ann.prefix.addr << " & " << std::hex << 
         ann.prefix.netmask << std::endl << "Origin:\t\t" << std::dec << ann.origin
         << std::endl << "Priority:\t" << ann.priority << std::endl 
         << "Recv'd from:\t" << std::dec << ann.received_from_asn;
     return os;
 }
-
-std::ostream& Announcement::to_csv(std::ostream &os) {
+template <typename PrefixType>
+std::ostream& Announcement<PrefixType>::to_csv(std::ostream &os) {
     os << prefix.to_cidr() << ',' << origin << ',' << received_from_asn << ',' << tstamp << '\n';
     return os;
 }
+
+template class Announcement<>;
+template class Announcement<uint128_t>;

--- a/src/Announcements/EZAnnouncement.cpp
+++ b/src/Announcements/EZAnnouncement.cpp
@@ -1,18 +1,18 @@
 #include "Announcements/EZAnnouncement.h"
 
 EZAnnouncement::EZAnnouncement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask,
-    uint32_t from_asn, int64_t timestamp /* = 0 */, bool from_attacker /* = false */) : Announcement(aorigin, aprefix, anetmask, from_asn, timestamp) {
+    uint32_t from_asn, int64_t timestamp /* = 0 */, bool from_attacker /* = false */) : Announcement<>(aorigin, aprefix, anetmask, from_asn, timestamp) {
 
     this->from_attacker = from_attacker;
 }
 
 EZAnnouncement::EZAnnouncement(uint32_t aorigin, uint32_t aprefix, uint32_t anetmask,
-    uint32_t pr, uint32_t from_asn, int64_t timestamp, bool a_from_monitor /* = false */, bool from_attacker /* = false */) : Announcement(aorigin, aprefix, anetmask, pr, from_asn, timestamp, a_from_monitor) {
+    uint32_t pr, uint32_t from_asn, int64_t timestamp, bool a_from_monitor /* = false */, bool from_attacker /* = false */) : Announcement<>(aorigin, aprefix, anetmask, pr, from_asn, timestamp, a_from_monitor) {
 
     this->from_attacker = from_attacker;
 }
 
-EZAnnouncement::EZAnnouncement(const EZAnnouncement& ann) : Announcement(ann) {
+EZAnnouncement::EZAnnouncement(const EZAnnouncement& ann) : Announcement<>(ann) {
     this->from_attacker = ann.from_attacker;
     this->as_path = ann.as_path;
 }

--- a/src/Announcements/ROVppAnnouncement.cpp
+++ b/src/Announcements/ROVppAnnouncement.cpp
@@ -27,7 +27,7 @@ ROVppAnnouncement::ROVppAnnouncement(uint32_t aorigin,
                  uint32_t aprefix, 
                  uint32_t anetmask,
                  uint32_t from_asn, 
-                 int64_t timestamp /* = 0 */) : Announcement(aorigin, aprefix, anetmask, from_asn, timestamp) {
+                 int64_t timestamp /* = 0 */) : Announcement<>(aorigin, aprefix, anetmask, from_asn, timestamp) {
     policy_index = 0;
     alt = 0;
     tiebreak_override = 0;
@@ -67,7 +67,7 @@ ROVppAnnouncement::ROVppAnnouncement(uint32_t aorigin,
 
 /** Copy constructor
  */
-ROVppAnnouncement::ROVppAnnouncement(const ROVppAnnouncement& ann) : Announcement(ann) {
+ROVppAnnouncement::ROVppAnnouncement(const ROVppAnnouncement& ann) : Announcement<>(ann) {
     alt = ann.alt;              
     policy_index = ann.policy_index;     
     tiebreak_override = ann.tiebreak_override;

--- a/src/Extrapolators/BaseExtrapolator.cpp
+++ b/src/Extrapolators/BaseExtrapolator.cpp
@@ -284,6 +284,7 @@ std::string BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType
 }
 
 //We love C++ class templating. Please find another way to do this. I want to be wrong.
-template class BaseExtrapolator<SQLQuerier, ASGraph, Announcement, AS>;
+template class BaseExtrapolator<SQLQuerier, ASGraph<>, Announcement<>, AS<>>;
+template class BaseExtrapolator<SQLQuerier, ASGraph<uint128_t>, Announcement<uint128_t>, AS<uint128_t>>;
 template class BaseExtrapolator<EZSQLQuerier, EZASGraph, EZAnnouncement, EZAS>;
 template class BaseExtrapolator<ROVppSQLQuerier, ROVppASGraph, ROVppAnnouncement, ROVppAS>;

--- a/src/Extrapolators/BaseExtrapolator.cpp
+++ b/src/Extrapolators/BaseExtrapolator.cpp
@@ -284,7 +284,7 @@ std::string BaseExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType
 }
 
 //We love C++ class templating. Please find another way to do this. I want to be wrong.
-template class BaseExtrapolator<SQLQuerier, ASGraph<>, Announcement<>, AS<>>;
-template class BaseExtrapolator<SQLQuerier, ASGraph<uint128_t>, Announcement<uint128_t>, AS<uint128_t>>;
+template class BaseExtrapolator<SQLQuerier<>, ASGraph<>, Announcement<>, AS<>>;
+template class BaseExtrapolator<SQLQuerier<uint128_t>, ASGraph<uint128_t>, Announcement<uint128_t>, AS<uint128_t>>;
 template class BaseExtrapolator<EZSQLQuerier, EZASGraph, EZAnnouncement, EZAS>;
 template class BaseExtrapolator<ROVppSQLQuerier, ROVppASGraph, ROVppAnnouncement, ROVppAS>;

--- a/src/Extrapolators/BlockedExtrapolator.cpp
+++ b/src/Extrapolators/BlockedExtrapolator.cpp
@@ -1,12 +1,13 @@
 #include "Extrapolators/BlockedExtrapolator.h"
 
-template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
-BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::~BlockedExtrapolator() {
+
+template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType, typename PrefixType>
+BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType, PrefixType>::~BlockedExtrapolator() {
 
 }
 
-template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
-void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::init() {
+template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType, typename PrefixType>
+void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType, PrefixType>::init() {
         // Make tmp directory if it does not exist
     DIR* dir = opendir("/dev/shm/bgp");
     if(!dir){
@@ -47,16 +48,16 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::i
     this->graph->create_graph_from_db(this->querier);
 }
 
-template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
-void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::perform_propagation() {
+template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType, typename PrefixType>
+void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType, PrefixType>::perform_propagation() {
     init();
 
     BOOST_LOG_TRIVIAL(info) << "Generating subnet blocks...";
     
     // Generate iteration blocks
-    std::vector<Prefix<>*> *prefix_blocks = new std::vector<Prefix<>*>; // Prefix blocks
-    std::vector<Prefix<>*> *subnet_blocks = new std::vector<Prefix<>*>; // Subnet blocks
-    Prefix<> *cur_prefix = new Prefix<>("0.0.0.0", "0.0.0.0"); // Start at 0.0.0.0/0
+    std::vector<Prefix<PrefixType>*> *prefix_blocks = new std::vector<Prefix<PrefixType>*>; // Prefix blocks
+    std::vector<Prefix<PrefixType>*> *subnet_blocks = new std::vector<Prefix<PrefixType>*>; // Subnet blocks
+    Prefix<PrefixType> *cur_prefix = new Prefix<PrefixType>("0.0.0.0", "0.0.0.0"); // Start at 0.0.0.0/0
     this->populate_blocks(cur_prefix, prefix_blocks, subnet_blocks); // Select blocks based on iteration size
     delete cur_prefix;
 
@@ -67,8 +68,8 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::p
     delete subnet_blocks;
 }
 
-template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
-void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::extrapolate(std::vector<Prefix<>*> *prefix_blocks, std::vector<Prefix<>*> *subnet_blocks) {
+template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType, typename PrefixType>
+void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType, PrefixType>::extrapolate(std::vector<Prefix<PrefixType>*> *prefix_blocks, std::vector<Prefix<PrefixType>*> *subnet_blocks) {
     BOOST_LOG_TRIVIAL(info) << "Beginning propagation...";
     
     // Seed MRT announcements and propagate
@@ -88,10 +89,10 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::e
     BOOST_LOG_TRIVIAL(info) << "Announcement count: " << announcement_count;
 }
 
-template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
-void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::populate_blocks(Prefix<>* p,
-                                                                            std::vector<Prefix<>*>* prefix_vector,
-                                                                            std::vector<Prefix<>*>* bloc_vector) { 
+template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType, typename PrefixType>
+void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType, PrefixType>::populate_blocks(Prefix<PrefixType>* p,
+                                                                            std::vector<Prefix<PrefixType>*>* prefix_vector,
+                                                                            std::vector<Prefix<PrefixType>*>* bloc_vector) { 
     // Find the number of announcements within the subnet
     pqxx::result r = this->querier->select_subnet_count(p);
     
@@ -104,14 +105,14 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::p
     if (r[0][0].as<uint32_t>() < this->iteration_size) {
         // Add to subnet block vector
         if (r[0][0].as<uint32_t>() > 0) {
-            Prefix<>* p_copy = new Prefix<>(p->addr, p->netmask);
+            Prefix<PrefixType>* p_copy = new Prefix<PrefixType>(p->addr, p->netmask);
             bloc_vector->push_back(p_copy);
         }
     } else {
         // Store the prefix if there are announcements for it specifically
         pqxx::result r2 = this->querier->select_prefix_count(p);
         if (r2[0][0].as<uint32_t>() > 0) {
-            Prefix<>* p_copy = new Prefix<>(p->addr, p->netmask);
+            Prefix<PrefixType>* p_copy = new Prefix<PrefixType>(p->addr, p->netmask);
             prefix_vector->push_back(p_copy);
         }
 
@@ -123,7 +124,7 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::p
         } else {
             new_mask = (p->netmask >> 1) | p->netmask;
         }
-        Prefix<>* p1 = new Prefix<>(p->addr, new_mask);
+        Prefix<PrefixType>* p1 = new Prefix<PrefixType>(p->addr, new_mask);
         
         // Second half: increase the prefix length by 1 and flip previous length bit
         int8_t sz = 0;
@@ -134,7 +135,7 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::p
             }
         }
         new_addr |= 1UL << (32 - sz - 1);
-        Prefix<>* p2 = new Prefix<>(new_addr, new_mask);
+        Prefix<PrefixType>* p2 = new Prefix<PrefixType>(new_addr, new_mask);
 
         // Recursive call on each new prefix subnet
         populate_blocks(p1, prefix_vector, bloc_vector);
@@ -145,13 +146,13 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::p
     }
 }
 
-template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
-void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::extrapolate_blocks(uint32_t &announcement_count, 
+template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType, typename PrefixType>
+void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType, PrefixType>::extrapolate_blocks(uint32_t &announcement_count, 
                                                                                                     int &iteration, 
                                                                                                     bool subnet, 
-                                                                                                    std::vector<Prefix<>*> *prefix_set) {
+                                                                                                    std::vector<Prefix<PrefixType>*> *prefix_set) {
     // For each unprocessed block of announcements 
-    for (Prefix<>* prefix : *prefix_set) {
+    for (Prefix<PrefixType>* prefix : *prefix_set) {
         BOOST_LOG_TRIVIAL(info) << "Selecting Announcements...";
         auto prefix_start = std::chrono::high_resolution_clock::now();
         
@@ -180,7 +181,7 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::e
             // Get row prefix
             std::string ip = ann_block[i]["host"].c_str();
             std::string mask = ann_block[i]["netmask"].c_str();
-            Prefix<> cur_prefix(ip, mask);
+            Prefix<PrefixType> cur_prefix(ip, mask);
             // Get row AS path
             std::string path_as_string(ann_block[i]["as_path"].as<std::string>());
             std::vector<uint32_t> *as_path = this->parse_path(path_as_string);
@@ -201,12 +202,12 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::e
 
             if(this->graph->inverse_results != NULL) {
                 // Assemble pair
-                auto prefix_origin = std::pair<Prefix<>, uint32_t>(cur_prefix, origin);
+                auto prefix_origin = std::pair<Prefix<PrefixType>, uint32_t>(cur_prefix, origin);
                 
                 // Insert the inverse results for this prefix
                 if (this->graph->inverse_results->find(prefix_origin) == this->graph->inverse_results->end()) {
                     // This is horrifying
-                    this->graph->inverse_results->insert(std::pair<std::pair<Prefix<>, uint32_t>, 
+                    this->graph->inverse_results->insert(std::pair<std::pair<Prefix<PrefixType>, uint32_t>, 
                                                             std::set<uint32_t>*>
                                                             (prefix_origin, new std::set<uint32_t>()));
                     
@@ -235,8 +236,8 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::e
     }
 }
 
-template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
-void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::give_ann_to_as_path(std::vector<uint32_t>* as_path, Prefix<> prefix, int64_t timestamp) {
+template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType, typename PrefixType>
+void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType, PrefixType>::give_ann_to_as_path(std::vector<uint32_t>* as_path, Prefix<PrefixType> prefix, int64_t timestamp) {
     // Handle empty as_path
     if (as_path->empty()) { 
         return;
@@ -376,7 +377,7 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::g
             as_on_path->process_announcement(ann, this->random_tiebraking);
             if (this->graph->inverse_results != NULL) {
                 auto set = this->graph->inverse_results->find(
-                        std::pair<Prefix<>,uint32_t>(ann.prefix, ann.origin));
+                        std::pair<Prefix<PrefixType>,uint32_t>(ann.prefix, ann.origin));
                 // Remove the AS from the prefix's inverse results
                 if (set != this->graph->inverse_results->end()) {
                     set->second->erase(as_on_path->asn);
@@ -396,8 +397,8 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::g
     }
 }
 
-template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType>
-void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::send_all_announcements(uint32_t asn, 
+template <class SQLQuerierType, class GraphType, class AnnouncementType, class ASType, typename PrefixType>
+void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType, PrefixType>::send_all_announcements(uint32_t asn, 
                                                                                                         bool to_providers, 
                                                                                                         bool to_peers, 
                                                                                                         bool to_customers) {
@@ -599,5 +600,6 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType>::s
     }
 }
 
-template class BlockedExtrapolator<SQLQuerier, ASGraph, Announcement, AS>;
+template class BlockedExtrapolator<SQLQuerier, ASGraph<>, Announcement<>, AS<>>;
+template class BlockedExtrapolator<SQLQuerier, ASGraph<uint128_t>, Announcement<uint128_t>, AS<uint128_t>, uint128_t>;
 template class BlockedExtrapolator<EZSQLQuerier, EZASGraph, EZAnnouncement, EZAS>;

--- a/src/Extrapolators/BlockedExtrapolator.cpp
+++ b/src/Extrapolators/BlockedExtrapolator.cpp
@@ -600,6 +600,6 @@ void BlockedExtrapolator<SQLQuerierType, GraphType, AnnouncementType, ASType, Pr
     }
 }
 
-template class BlockedExtrapolator<SQLQuerier, ASGraph<>, Announcement<>, AS<>>;
-template class BlockedExtrapolator<SQLQuerier, ASGraph<uint128_t>, Announcement<uint128_t>, AS<uint128_t>, uint128_t>;
-template class BlockedExtrapolator<EZSQLQuerier, EZASGraph, EZAnnouncement, EZAS>;
+template class BlockedExtrapolator<SQLQuerier<>, ASGraph<>, Announcement<>, AS<>, uint32_t>;
+template class BlockedExtrapolator<SQLQuerier<uint128_t>, ASGraph<uint128_t>, Announcement<uint128_t>, AS<uint128_t>, uint128_t>;
+template class BlockedExtrapolator<EZSQLQuerier, EZASGraph, EZAnnouncement, EZAS, uint32_t>;

--- a/src/Extrapolators/Extrapolator.cpp
+++ b/src/Extrapolators/Extrapolator.cpp
@@ -23,31 +23,31 @@
 
 #include "Extrapolators/Extrapolator.h"
 
-//template <typename PrefixType>
-// Extrapolator<PrefixType>::Extrapolator(bool random_tiebraking,
-//                     bool store_results, 
-//                     bool store_invert_results, 
-//                     bool store_depref_results, 
-//                     std::string announcement_table,
-//                     std::string results_table, 
-//                     std::string inverse_results_table, 
-//                     std::string depref_results_table,
-//                     std::string full_path_results_table,
-//                     std::string config_section, 
-//                     uint32_t iteration_size,
-//                     int exclude_as_number,
-//                     uint32_t mh_mode,
-//                     bool origin_only,
-//                     std::vector<uint32_t> *full_path_asns) : BlockedExtrapolator<SQLQuerier<PrefixType>, ASGraph<PrefixType>, Announcement<PrefixType>, AS<PrefixType>, Prefix<PrefixType>>(random_tiebraking, store_results, store_invert_results, store_depref_results, iteration_size, mh_mode, origin_only, full_path_asns) {
+template <typename PrefixType>
+Extrapolator<PrefixType>::Extrapolator(bool random_tiebraking,
+                    bool store_results, 
+                    bool store_invert_results, 
+                    bool store_depref_results, 
+                    std::string announcement_table,
+                    std::string results_table, 
+                    std::string inverse_results_table, 
+                    std::string depref_results_table,
+                    std::string full_path_results_table,
+                    std::string config_section, 
+                    uint32_t iteration_size,
+                    int exclude_as_number,
+                    uint32_t mh_mode,
+                    bool origin_only,
+                    std::vector<uint32_t> *full_path_asns) : BlockedExtrapolator<SQLQuerier<PrefixType>, ASGraph<PrefixType>, Announcement<PrefixType>, AS<PrefixType>, PrefixType>(random_tiebraking, store_results, store_invert_results, store_depref_results, iteration_size, mh_mode, origin_only, full_path_asns) {
 
-//     this->graph = new ASGraph<PrefixType>(store_invert_results, store_depref_results);
-//     this->querier = new SQLQuerier<PrefixType>(announcement_table, results_table, inverse_results_table, depref_results_table, full_path_results_table, exclude_as_number, config_section);
-// }
+    this->graph = new ASGraph<PrefixType>(store_invert_results, store_depref_results);
+    this->querier = new SQLQuerier<PrefixType>(announcement_table, results_table, inverse_results_table, depref_results_table, full_path_results_table, exclude_as_number, config_section);
+}
 
-// template <typename PrefixType>
-// Extrapolator<PrefixType>::Extrapolator() : Extrapolator<PrefixType>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-//                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE,
-//                                             DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, DEFAULT_MH_MODE, DEFAULT_ORIGIN_ONLY, NULL) { }
+template <typename PrefixType>
+Extrapolator<PrefixType>::Extrapolator() : Extrapolator<PrefixType>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE,
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, DEFAULT_MH_MODE, DEFAULT_ORIGIN_ONLY, NULL) { }
 
 template <typename PrefixType>
 Extrapolator<PrefixType>::~Extrapolator() { }

--- a/src/Extrapolators/Extrapolator.cpp
+++ b/src/Extrapolators/Extrapolator.cpp
@@ -23,29 +23,34 @@
 
 #include "Extrapolators/Extrapolator.h"
 
-Extrapolator::Extrapolator(bool random_tiebraking,
-                            bool store_results, 
-                            bool store_invert_results, 
-                            bool store_depref_results, 
-                            std::string announcement_table,
-                            std::string results_table, 
-                            std::string inverse_results_table, 
-                            std::string depref_results_table,
-                            std::string full_path_results_table, 
-                            std::string config_section, 
-                            uint32_t iteration_size,
-                            int exclude_as_number,
-                            uint32_t mh_mode,
-                            bool origin_only,
-                            std::vector<uint32_t> *full_path_asns) : BlockedExtrapolator(random_tiebraking, store_results, store_invert_results, store_depref_results, iteration_size, mh_mode, origin_only, full_path_asns) {
+template <typename PrefixType>
+Extrapolator<PrefixType>::Extrapolator(bool random_tiebraking,
+                    bool store_results, 
+                    bool store_invert_results, 
+                    bool store_depref_results, 
+                    std::string announcement_table,
+                    std::string results_table, 
+                    std::string inverse_results_table, 
+                    std::string depref_results_table,
+                    std::string full_path_results_table,
+                    std::string config_section, 
+                    uint32_t iteration_size,
+                    int exclude_as_number,
+                    uint32_t mh_mode,
+                    bool origin_only,
+                    std::vector<uint32_t> *full_path_asns) : BlockedExtrapolator<SQLQuerier, ASGraph<PrefixType>, Announcement<PrefixType>, AS<PrefixType>, Prefix<PrefixType>>(random_tiebraking, store_results, store_invert_results, store_depref_results, iteration_size, mh_mode, origin_only, full_path_asns) {
 
-    graph = new ASGraph(store_invert_results, store_depref_results);
-    querier = new SQLQuerier(announcement_table, results_table, inverse_results_table, depref_results_table, full_path_results_table, exclude_as_number, config_section);
+    this->graph = new ASGraph<PrefixType>(store_invert_results, store_depref_results);
+    this->querier = new SQLQuerier(announcement_table, results_table, inverse_results_table, depref_results_table, full_path_results_table, exclude_as_number, config_section);
 }
 
-Extrapolator::Extrapolator() : Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+template <typename PrefixType>
+Extrapolator<PrefixType>::Extrapolator() : Extrapolator<PrefixType>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE,
                                             DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, DEFAULT_MH_MODE, DEFAULT_ORIGIN_ONLY, NULL) { }
 
-Extrapolator::~Extrapolator() { }
+template <typename PrefixType>
+Extrapolator<PrefixType>::~Extrapolator() { }
 
+template class Extrapolator<>;
+template class Extrapolator<uint128_t>;

--- a/src/Extrapolators/Extrapolator.cpp
+++ b/src/Extrapolators/Extrapolator.cpp
@@ -23,31 +23,31 @@
 
 #include "Extrapolators/Extrapolator.h"
 
-template <typename PrefixType>
-Extrapolator<PrefixType>::Extrapolator(bool random_tiebraking,
-                    bool store_results, 
-                    bool store_invert_results, 
-                    bool store_depref_results, 
-                    std::string announcement_table,
-                    std::string results_table, 
-                    std::string inverse_results_table, 
-                    std::string depref_results_table,
-                    std::string full_path_results_table,
-                    std::string config_section, 
-                    uint32_t iteration_size,
-                    int exclude_as_number,
-                    uint32_t mh_mode,
-                    bool origin_only,
-                    std::vector<uint32_t> *full_path_asns) : BlockedExtrapolator<SQLQuerier, ASGraph<PrefixType>, Announcement<PrefixType>, AS<PrefixType>, Prefix<PrefixType>>(random_tiebraking, store_results, store_invert_results, store_depref_results, iteration_size, mh_mode, origin_only, full_path_asns) {
+//template <typename PrefixType>
+// Extrapolator<PrefixType>::Extrapolator(bool random_tiebraking,
+//                     bool store_results, 
+//                     bool store_invert_results, 
+//                     bool store_depref_results, 
+//                     std::string announcement_table,
+//                     std::string results_table, 
+//                     std::string inverse_results_table, 
+//                     std::string depref_results_table,
+//                     std::string full_path_results_table,
+//                     std::string config_section, 
+//                     uint32_t iteration_size,
+//                     int exclude_as_number,
+//                     uint32_t mh_mode,
+//                     bool origin_only,
+//                     std::vector<uint32_t> *full_path_asns) : BlockedExtrapolator<SQLQuerier<PrefixType>, ASGraph<PrefixType>, Announcement<PrefixType>, AS<PrefixType>, Prefix<PrefixType>>(random_tiebraking, store_results, store_invert_results, store_depref_results, iteration_size, mh_mode, origin_only, full_path_asns) {
 
-    this->graph = new ASGraph<PrefixType>(store_invert_results, store_depref_results);
-    this->querier = new SQLQuerier(announcement_table, results_table, inverse_results_table, depref_results_table, full_path_results_table, exclude_as_number, config_section);
-}
+//     this->graph = new ASGraph<PrefixType>(store_invert_results, store_depref_results);
+//     this->querier = new SQLQuerier<PrefixType>(announcement_table, results_table, inverse_results_table, depref_results_table, full_path_results_table, exclude_as_number, config_section);
+// }
 
-template <typename PrefixType>
-Extrapolator<PrefixType>::Extrapolator() : Extrapolator<PrefixType>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE,
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, DEFAULT_MH_MODE, DEFAULT_ORIGIN_ONLY, NULL) { }
+// template <typename PrefixType>
+// Extrapolator<PrefixType>::Extrapolator() : Extrapolator<PrefixType>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+//                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE,
+//                                             DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, DEFAULT_MH_MODE, DEFAULT_ORIGIN_ONLY, NULL) { }
 
 template <typename PrefixType>
 Extrapolator<PrefixType>::~Extrapolator() { }

--- a/src/Extrapolators/ROVppExtrapolator.cpp
+++ b/src/Extrapolators/ROVppExtrapolator.cpp
@@ -608,7 +608,7 @@ void ROVppExtrapolator::send_all_announcements(uint32_t asn,
 bool ROVppExtrapolator::loop_check(Prefix<> p, const ROVppAS& cur_as, uint32_t a, int d) {
     if (d > 100) { BOOST_LOG_TRIVIAL(error) << "Maximum depth exceeded during traceback."; return true; }
     auto ann_pair = cur_as.loc_rib->find(p);
-    const Announcement &ann = ann_pair->second;
+    const Announcement<> &ann = ann_pair->second;
     // i wonder if a cabinet holding a subwoofer counts as a bass case
     // Ba dum tss, nice
     if (ann.received_from_asn == a) { return true; }

--- a/src/Graphs/ASGraph.cpp
+++ b/src/Graphs/ASGraph.cpp
@@ -23,14 +23,20 @@
 
 #include "Graphs/ASGraph.h"
 
-ASGraph::ASGraph(bool store_inverse_results, bool store_depref_results) : BaseGraph(store_inverse_results, store_depref_results) {
+template <typename PrefixType>
+ASGraph<PrefixType>::ASGraph(bool store_inverse_results, bool store_depref_results) : BaseGraph<AS<PrefixType>, PrefixType>(store_inverse_results, store_depref_results) {
 
 }
 
-ASGraph::~ASGraph() {
+template <typename PrefixType>
+ASGraph<PrefixType>::~ASGraph() {
 
 }
 
-AS* ASGraph::createNew(uint32_t asn) {
-    return new AS(asn, store_depref_results, inverse_results);
+template <typename PrefixType>
+AS<PrefixType>* ASGraph<PrefixType>::createNew(uint32_t asn) {
+    return new AS<PrefixType>(asn, this->store_depref_results, this->inverse_results);
 }
+
+template class ASGraph<>;
+template class ASGraph<uint128_t>;

--- a/src/Graphs/BaseGraph.cpp
+++ b/src/Graphs/BaseGraph.cpp
@@ -32,8 +32,8 @@
 #include "Graphs/ASGraph.h"
 #include "ASes/AS.h"
 
-template <class ASType>
-BaseGraph<ASType>::~BaseGraph() {
+template <class ASType, typename PrefixType>
+BaseGraph<ASType, PrefixType>::~BaseGraph() {
     for (auto const& as : *ases)
         delete as.second;
     delete ases;
@@ -57,8 +57,8 @@ BaseGraph<ASType>::~BaseGraph() {
     delete non_stubs;
 }
 
-template <class ASType>
-void BaseGraph<ASType>::clear_announcements() {
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::clear_announcements() {
     for (auto const& as : *ases)
         as.second->clear_announcements();
 
@@ -69,8 +69,8 @@ void BaseGraph<ASType>::clear_announcements() {
     }
 }
 
-template <class ASType>
-void BaseGraph<ASType>::add_relationship(uint32_t asn, 
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::add_relationship(uint32_t asn, 
                                             uint32_t neighbor_asn, 
                                             int relation) {
     auto search = ases->find(asn);
@@ -83,16 +83,16 @@ void BaseGraph<ASType>::add_relationship(uint32_t asn,
     search->second->add_neighbor(neighbor_asn, relation);
 }
 
-template <class ASType>
-uint32_t BaseGraph<ASType>::translate_asn(uint32_t asn) {
+template <class ASType, typename PrefixType>
+uint32_t BaseGraph<ASType, PrefixType>::translate_asn(uint32_t asn) {
     auto search = component_translation->find(asn);
     if(search == component_translation->end())
         return asn; 
     return search->second;
 }
 
-template <class ASType>
-void BaseGraph<ASType>::process(SQLQuerier *querier) {
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::process(SQLQuerier<PrefixType> *querier) {
     remove_stubs(querier);
     tarjan();
     combine_components();
@@ -100,8 +100,8 @@ void BaseGraph<ASType>::process(SQLQuerier *querier) {
     decide_ranks();
 }
 
-template <class ASType>
-void BaseGraph<ASType>::create_graph_from_db(SQLQuerier *querier) {
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::create_graph_from_db(SQLQuerier<PrefixType> *querier) {
     // Assemble Peers
     pqxx::result R = querier->select_from_table(PEERS_TABLE);
     for (pqxx::result::const_iterator c = R.begin(); c!=R.end(); ++c){
@@ -123,8 +123,8 @@ void BaseGraph<ASType>::create_graph_from_db(SQLQuerier *querier) {
     process(querier);
 }
 
-template <class ASType>
-void BaseGraph<ASType>::remove_stubs(SQLQuerier *querier) {
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::remove_stubs(SQLQuerier<PrefixType> *querier) {
     std::vector<ASType*> to_remove;
     // For all ASes in the graph
     for (auto &as : *ases) {
@@ -161,8 +161,8 @@ void BaseGraph<ASType>::remove_stubs(SQLQuerier *querier) {
     save_non_stubs_to_db(querier);
 }
 
-template <class ASType>
-void BaseGraph<ASType>::save_stubs_to_db(SQLQuerier *querier) {
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::save_stubs_to_db(SQLQuerier<PrefixType> *querier) {
     DIR* dir = opendir("/dev/shm/bgp");
     if(!dir)
         mkdir("/dev/shm/bgp",0777);
@@ -182,8 +182,8 @@ void BaseGraph<ASType>::save_stubs_to_db(SQLQuerier *querier) {
     std::remove(file_name.c_str());
 }
 
-template <class ASType>
-void BaseGraph<ASType>::save_non_stubs_to_db(SQLQuerier *querier) {
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::save_non_stubs_to_db(SQLQuerier<PrefixType> *querier) {
     DIR* dir = opendir("/dev/shm/bgp");
     if(!dir)
         mkdir("/dev/shm/bgp",0777);
@@ -203,8 +203,8 @@ void BaseGraph<ASType>::save_non_stubs_to_db(SQLQuerier *querier) {
     std::remove(file_name.c_str());
 }
 
-template <class ASType>
-void BaseGraph<ASType>::save_supernodes_to_db(SQLQuerier *querier) {
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::save_supernodes_to_db(SQLQuerier<PrefixType> *querier) {
     DIR* dir = opendir("/dev/shm/bgp");
     if(!dir)
         mkdir("/dev/shm/bgp",0777);
@@ -237,8 +237,8 @@ void BaseGraph<ASType>::save_supernodes_to_db(SQLQuerier *querier) {
     std::remove(file_name.c_str());
 }
 
-template <class ASType>
-void BaseGraph<ASType>::decide_ranks() {
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::decide_ranks() {
     ases_by_rank->clear();
 
     // Initial set of customer ASes at the bottom of the DAG
@@ -276,8 +276,8 @@ void BaseGraph<ASType>::decide_ranks() {
     return;
 }
 
-template <class ASType>
-void BaseGraph<ASType>::tarjan() {
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::tarjan() {
     int index = 0;
     std::stack<ASType*> s;
 
@@ -287,8 +287,8 @@ void BaseGraph<ASType>::tarjan() {
     return;
 }
 
-template <class ASType>
-void BaseGraph<ASType>::tarjan_helper(ASType *as, int &index, std::stack<ASType*> &s) {
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::tarjan_helper(ASType *as, int &index, std::stack<ASType*> &s) {
     as->index = index;
     as->lowlink = index;
     index++;
@@ -322,8 +322,8 @@ void BaseGraph<ASType>::tarjan_helper(ASType *as, int &index, std::stack<ASType*
     }
 }
 
-template <class ASType>
-void BaseGraph<ASType>::combine_components() {
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::combine_components() {
     
     // For each strongly connected component
     for (auto const& component : *components) {
@@ -427,15 +427,15 @@ void BaseGraph<ASType>::combine_components() {
     return;
 }
 
-template <class ASType>
-void BaseGraph<ASType>::printDebug() {
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::printDebug() {
     for (auto const& as : *ases)
         BOOST_LOG_TRIVIAL(debug) << as.first << ':' << as.second->asn;
     return; 
 }
 
-template <class ASType>
-void BaseGraph<ASType>::to_graphviz(std::ostream &os) {
+template <class ASType, typename PrefixType>
+void BaseGraph<ASType, PrefixType>::to_graphviz(std::ostream &os) {
     std::string id = "";
     for (auto const &as : *ases) {
         os << "dot.node('" << as.second->asn << "', '" << as.second->asn << "')" << std::endl;
@@ -454,6 +454,7 @@ std::ostream& operator<<(std::ostream &os, const BaseGraph<U>& asg) {
 }
 
 //We love C++
-template class BaseGraph<AS>;
+template class BaseGraph<AS<>>;
+template class BaseGraph<AS<uint128_t>, uint128_t>;
 template class BaseGraph<EZAS>;
 template class BaseGraph<ROVppAS>;

--- a/src/Graphs/EZASGraph.cpp
+++ b/src/Graphs/EZASGraph.cpp
@@ -35,7 +35,7 @@ void EZASGraph::disconnectAttackerEdges() {
     attacker_edge_removal->clear();
 }
 
-void EZASGraph::distributeAttackersVictims(SQLQuerier* querier) {
+void EZASGraph::distributeAttackersVictims(SQLQuerier<>* querier) {
     origin_to_attacker_victim->clear();
     victim_to_prefixes->clear();
 
@@ -64,7 +64,7 @@ void EZASGraph::distributeAttackersVictims(SQLQuerier* querier) {
     }
 }
 
-void EZASGraph::process(SQLQuerier* querier) {
+void EZASGraph::process(SQLQuerier<>* querier) {
     //We definately want stubs/edge ASes
     distributeAttackersVictims(querier);
     tarjan();

--- a/src/Graphs/ROVppASGraph.cpp
+++ b/src/Graphs/ROVppASGraph.cpp
@@ -37,7 +37,7 @@ ROVppAS* ROVppASGraph::createNew(uint32_t asn) {
     return new ROVppAS(asn, attackers);
 }
 
-void ROVppASGraph::process(SQLQuerier *querier) {
+void ROVppASGraph::process(SQLQuerier<> *querier) {
     // Main difference is remove_stubs isn't being called
     tarjan();
     combine_components();

--- a/src/Graphs/RanGraph.cpp
+++ b/src/Graphs/RanGraph.cpp
@@ -22,8 +22,8 @@
  ************************************************************************/
 #include "Graphs/RanGraph.h"
 
-ASGraph* ran_graph(int num_edges, int num_vertices) {
-    ASGraph* graph = new ASGraph(false, false);
+ASGraph<>* ran_graph(int num_edges, int num_vertices) {
+    ASGraph<>* graph = new ASGraph<>(false, false);
     //srand(time(NULL));
     //v = 11+rand()%10;
     //e = rand()%((v*(v-1))/2);
@@ -50,11 +50,11 @@ ASGraph* ran_graph(int num_edges, int num_vertices) {
 }
 
 
-bool cyclic_util(ASGraph* graph, int asn, std::map<uint32_t, bool>* visited, std::map<uint32_t, bool>* recStack) { 
+bool cyclic_util(ASGraph<>* graph, int asn, std::map<uint32_t, bool>* visited, std::map<uint32_t, bool>* recStack) { 
     if (visited->find(asn)->second == false) {
         visited->find(asn)->second = true;
         recStack->find(asn)->second = true;
-        AS* cur_AS = graph->ases->find(asn)->second;
+        AS<>* cur_AS = graph->ases->find(asn)->second;
         for (auto &provider_asn : *cur_AS->providers) {
             if (!visited->find(provider_asn)->second &&
                 cyclic_util(graph, provider_asn, visited, recStack)) {
@@ -69,7 +69,7 @@ bool cyclic_util(ASGraph* graph, int asn, std::map<uint32_t, bool>* visited, std
 }
 
 
-bool is_cyclic(ASGraph* graph) {
+bool is_cyclic(ASGraph<>* graph) {
     auto visited = new std::map<uint32_t, bool>;
     auto recStack = new std::map<uint32_t, bool>;
     

--- a/src/SQLQueriers/EZSQLQuerier.cpp
+++ b/src/SQLQueriers/EZSQLQuerier.cpp
@@ -1,6 +1,6 @@
 #include "SQLQueriers/EZSQLQuerier.h"
 
-EZSQLQuerier::EZSQLQuerier(std::string a, std::string r, std::string i, std::string d, std::string f, int n, std::string s) : SQLQuerier(a, r, i, d, f, n, s) {
+EZSQLQuerier::EZSQLQuerier(std::string a, std::string r, std::string i, std::string d, std::string f, int n, std::string s) : SQLQuerier<>(a, r, i, d, f, n, s) {
     
 }
 

--- a/src/SQLQueriers/ROVppSQLQuerier.cpp
+++ b/src/SQLQueriers/ROVppSQLQuerier.cpp
@@ -36,7 +36,7 @@ ROVppSQLQuerier::ROVppSQLQuerier(std::vector<std::string> policy_tables /* = std
                                     std::string simulation_table /* = ROVPP_SIMULATION_TABLE */,
                                     int exclude_as_number /* = -1 */,
                                     std::string config_section /* = "bgp" */)
-    : SQLQuerier(announcement_table, results_table, inverse_results_table, depref_results_table, full_path_results_table, exclude_as_number, config_section) {
+    : SQLQuerier<>(announcement_table, results_table, inverse_results_table, depref_results_table, full_path_results_table, exclude_as_number, config_section) {
     
     this->policy_tables = policy_tables;
     this->results_table = results_table;

--- a/src/SQLQueriers/SQLQuerier.cpp
+++ b/src/SQLQueriers/SQLQuerier.cpp
@@ -23,7 +23,8 @@
 
 #include "SQLQueriers/SQLQuerier.h"
 
-SQLQuerier::SQLQuerier(std::string announcements_table /* = ANNOUNCEMENTS_TABLE */,
+template <typename PrefixType>
+SQLQuerier<PrefixType>::SQLQuerier(std::string announcements_table /* = ANNOUNCEMENTS_TABLE */,
                         std::string results_table /* = RESULTS_TABLE */, 
                         std::string inverse_results_table /* = INVERSE_RESULTS_TABLE */, 
                         std::string depref_results_table /* = DEPREF_RESULTS_TABLE */,
@@ -53,7 +54,8 @@ SQLQuerier::SQLQuerier(std::string announcements_table /* = ANNOUNCEMENTS_TABLE 
     }
 }
 
-SQLQuerier::~SQLQuerier() {
+template <typename PrefixType>
+SQLQuerier<PrefixType>::~SQLQuerier() {
     C->disconnect();
     delete C;
 }
@@ -61,7 +63,8 @@ SQLQuerier::~SQLQuerier() {
 
 /** Reads credentials/connection info from .conf file
  */
-void SQLQuerier::read_config() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::read_config() {
     using namespace std;
 
     BOOST_LOG_TRIVIAL(info) << "Config section: " << config_section;
@@ -116,7 +119,8 @@ void SQLQuerier::read_config() {
 
 /** Opens a connection to the SQL database.
  */
-void SQLQuerier::open_connection() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::open_connection() {
     std::ostringstream stream;
     stream << "dbname = " << db_name;
     stream << " user = " << user;
@@ -140,7 +144,8 @@ void SQLQuerier::open_connection() {
 
 /** Closes the connection to the SQL database.
  */
-void SQLQuerier::close_connection() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::close_connection() {
     C->disconnect();
 }
 
@@ -150,7 +155,8 @@ void SQLQuerier::close_connection() {
  *  @param sql
  *  @param insert
  */
-pqxx::result SQLQuerier::execute(std::string sql, bool insert) {
+template <typename PrefixType>
+pqxx::result SQLQuerier<PrefixType>::execute(std::string sql, bool insert) {
     pqxx::result R;
     if(insert){
         //TODO maybe make one work object once on construction
@@ -181,7 +187,8 @@ pqxx::result SQLQuerier::execute(std::string sql, bool insert) {
  *  @param table_name The name of the table to SELECT from
  *  @param limit The limit of the number of values to SELECT
  */
-pqxx::result SQLQuerier::select_from_table(std::string table_name, int limit) {
+template <typename PrefixType>
+pqxx::result SQLQuerier<PrefixType>::select_from_table(std::string table_name, int limit) {
     std::string sql = "SELECT * FROM " + table_name;
     if (limit) {
         sql += " LIMIT " + std::to_string(limit);
@@ -194,7 +201,8 @@ pqxx::result SQLQuerier::select_from_table(std::string table_name, int limit) {
  *
  * @param p The prefix for which we SELECT
  */
-pqxx::result SQLQuerier::select_prefix_count(Prefix* p) {
+template <typename PrefixType>
+pqxx::result SQLQuerier<PrefixType>::select_prefix_count(Prefix<PrefixType>* p) {
     std::string cidr = p->to_cidr();
     std::string sql = "SELECT COUNT(*) FROM " + announcements_table;
 
@@ -213,7 +221,8 @@ pqxx::result SQLQuerier::select_prefix_count(Prefix* p) {
  *
  * @param p The prefix for which we SELECT
  */
-pqxx::result SQLQuerier::select_prefix_ann(Prefix* p) {
+template <typename PrefixType>
+pqxx::result SQLQuerier<PrefixType>::select_prefix_ann(Prefix<PrefixType>* p) {
     std::string cidr = p->to_cidr();
     std::string sql = "SELECT host(prefix), netmask(prefix), as_path, origin, time FROM " + announcements_table;
 
@@ -231,7 +240,8 @@ pqxx::result SQLQuerier::select_prefix_ann(Prefix* p) {
  *
  * @param p The prefix defining the subnet
  */
-pqxx::result SQLQuerier::select_subnet_count(Prefix* p) {
+template <typename PrefixType>
+pqxx::result SQLQuerier<PrefixType>::select_subnet_count(Prefix<PrefixType>* p) {
     std::string cidr = p->to_cidr();
     std::string sql = "SELECT COUNT(*) FROM " + announcements_table;
 
@@ -249,7 +259,8 @@ pqxx::result SQLQuerier::select_subnet_count(Prefix* p) {
  *
  * @param p The prefix defining the subnet
  */
-pqxx::result SQLQuerier::select_subnet_ann(Prefix* p) {
+template <typename PrefixType>
+pqxx::result SQLQuerier<PrefixType>::select_subnet_ann(Prefix<PrefixType>* p) {
     std::string cidr = p->to_cidr();
     std::string sql = "SELECT host(prefix), netmask(prefix), as_path, origin, time FROM " + announcements_table;
 
@@ -265,7 +276,8 @@ pqxx::result SQLQuerier::select_subnet_ann(Prefix* p) {
 
 /** this should use the STUBS_TABLE macro
  */
-void SQLQuerier::clear_stubs_from_db() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::clear_stubs_from_db() {
     std::string sql = std::string("DROP TABLE IF EXISTS " STUBS_TABLE ";");
     execute(sql);
 }
@@ -273,7 +285,8 @@ void SQLQuerier::clear_stubs_from_db() {
 
 /** Takes a .csv filename and bulk copies all elements to the stubs table.
  */
-void SQLQuerier::clear_non_stubs_from_db() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::clear_non_stubs_from_db() {
     std::string sql = std::string("DROP TABLE IF EXISTS " NON_STUBS_TABLE ";");
     execute(sql);
 }
@@ -281,7 +294,8 @@ void SQLQuerier::clear_non_stubs_from_db() {
 
 /** Takes a .csv filename and bulk copies all elements to the stubs table.
  */
-void SQLQuerier::clear_supernodes_from_db() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::clear_supernodes_from_db() {
     std::string sql = std::string("DROP TABLE IF EXISTS " SUPERNODES_TABLE ";");
     execute(sql);
 }
@@ -289,7 +303,8 @@ void SQLQuerier::clear_supernodes_from_db() {
 
 /** Instantiates a new, empty stubs table in the database, if it doesn't exist.
  */
-void SQLQuerier::create_stubs_tbl() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::create_stubs_tbl() {
     std::string sql = std::string("CREATE TABLE IF NOT EXISTS " STUBS_TABLE " (stub_asn BIGSERIAL PRIMARY KEY,parent_asn bigint);");
     BOOST_LOG_TRIVIAL(info) << "Creating stubs table...";
     execute(sql, false);
@@ -298,7 +313,8 @@ void SQLQuerier::create_stubs_tbl() {
 
 /** Instantiates a new, empty non_stubs table in the database, if it doesn't exist.
  */
-void SQLQuerier::create_non_stubs_tbl() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::create_non_stubs_tbl() {
     std::string sql = std::string("CREATE TABLE IF NOT EXISTS " NON_STUBS_TABLE " (non_stub_asn BIGSERIAL PRIMARY KEY);");
     BOOST_LOG_TRIVIAL(info) << "Creating non_stubs table...";
     execute(sql, false);
@@ -307,7 +323,8 @@ void SQLQuerier::create_non_stubs_tbl() {
 
 /**  Instantiates a new, empty supernodes table in the database, if it doesn't exist.
  */
-void SQLQuerier::create_supernodes_tbl() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::create_supernodes_tbl() {
     std::string sql = std::string("CREATE TABLE IF NOT EXISTS " SUPERNODES_TABLE "(supernode_asn BIGSERIAL PRIMARY KEY, supernode_lowest_asn bigint)");
     BOOST_LOG_TRIVIAL(info) << "Creating supernodes table...";
     execute(sql, false);
@@ -316,7 +333,8 @@ void SQLQuerier::create_supernodes_tbl() {
 
 /** Takes a .csv filename and bulk copies all elements to the stubs table.
  */
-void SQLQuerier::copy_stubs_to_db(std::string file_name) {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::copy_stubs_to_db(std::string file_name) {
     std::string sql = "COPY " STUBS_TABLE "(stub_asn,parent_asn) FROM '" +
                       file_name + "' WITH (FORMAT csv)";
     execute(sql);
@@ -325,7 +343,8 @@ void SQLQuerier::copy_stubs_to_db(std::string file_name) {
 
 /** Takes a .csv filename and bulk copies all elements to the non-stubs table.
  */
-void SQLQuerier::copy_non_stubs_to_db(std::string file_name) {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::copy_non_stubs_to_db(std::string file_name) {
     std::string sql = "COPY " NON_STUBS_TABLE "(non_stub_asn) FROM '" +
                       file_name + "' WITH (FORMAT csv)";
     execute(sql);
@@ -334,7 +353,8 @@ void SQLQuerier::copy_non_stubs_to_db(std::string file_name) {
 
 /** Takes a .csv filename and bulk copies all elements to the supernodes table.
  */
-void SQLQuerier::copy_supernodes_to_db(std::string file_name) {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::copy_supernodes_to_db(std::string file_name) {
     std::string sql = "COPY " SUPERNODES_TABLE "(supernode_asn,supernode_lowest_asn) FROM '" +
                       file_name + "' WITH (FORMAT csv)";
     execute(sql);
@@ -343,7 +363,8 @@ void SQLQuerier::copy_supernodes_to_db(std::string file_name) {
 
 /** Drop the Querier's results table.
  */
-void SQLQuerier::clear_results_from_db() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::clear_results_from_db() {
     std::string sql = std::string("DROP TABLE IF EXISTS " + results_table + ";");
     execute(sql);
 }
@@ -351,7 +372,8 @@ void SQLQuerier::clear_results_from_db() {
 
 /** Drop the Querier's depref table.
  */
-void SQLQuerier::clear_depref_from_db() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::clear_depref_from_db() {
     std::string sql = std::string("DROP TABLE IF EXISTS " + depref_table + ";");
     execute(sql);
 }
@@ -359,21 +381,24 @@ void SQLQuerier::clear_depref_from_db() {
 
 /** Drop the Querier's inverse results table.
  */
-void SQLQuerier::clear_inverse_from_db() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::clear_inverse_from_db() {
     std::string sql = std::string("DROP TABLE IF EXISTS " + inverse_results_table + ";");
     execute(sql);
 }
 
 /** Drop the Querier's full path results table.
  */
-void SQLQuerier::clear_full_path_from_db() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::clear_full_path_from_db() {
     std::string sql = std::string("DROP TABLE IF EXISTS " + full_path_results_table + ";");
     execute(sql);
 }
 
 /** Instantiates a new, empty results table in the database, dropping the old table.
  */
-void SQLQuerier::create_results_tbl() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::create_results_tbl() {
     /**
     std::string sql = std::string("CREATE UNLOGGED TABLE IF NOT EXISTS " + results_table + " (ann_id serial PRIMARY KEY,\
     */
@@ -388,7 +413,8 @@ void SQLQuerier::create_results_tbl() {
  *
  * In addition to all of the columns in the results table, this table includes the as_path.
  */
-void SQLQuerier::create_full_path_results_tbl() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::create_full_path_results_tbl() {
     std::string sql = std::string("CREATE UNLOGGED TABLE IF NOT EXISTS " + full_path_results_table + " (\
     asn bigint,prefix cidr, origin bigint, received_from_asn \
     bigint, time bigint, as_path bigint[]); GRANT ALL ON TABLE " + full_path_results_table + " TO bgp_user;");
@@ -398,7 +424,8 @@ void SQLQuerier::create_full_path_results_tbl() {
 
 /** Instantiates a new, empty depref table in the database, dropping the old table.
  */
-void SQLQuerier::create_depref_tbl() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::create_depref_tbl() {
     std::string sql = std::string("CREATE UNLOGGED TABLE IF NOT EXISTS " + depref_table + " (\
     asn bigint,prefix cidr, origin bigint, received_from_asn \
     bigint, time bigint); GRANT ALL ON TABLE " + depref_table + " TO bgp_user;");
@@ -409,7 +436,8 @@ void SQLQuerier::create_depref_tbl() {
 
 /** Instantiates a new, empty inverse results table in the database, dropping the old table.
  */
-void SQLQuerier::create_inverse_results_tbl() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::create_inverse_results_tbl() {
     std::string sql;
     sql = std::string("CREATE UNLOGGED TABLE IF NOT EXISTS ") + inverse_results_table + 
     "(asn bigint,prefix cidr, origin bigint) ";
@@ -422,7 +450,8 @@ void SQLQuerier::create_inverse_results_tbl() {
 
 /** Takes a .csv filename and bulk copies all elements to the results table.
  */
-void SQLQuerier::copy_results_to_db(std::string file_name) {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::copy_results_to_db(std::string file_name) {
     std::string sql = std::string("COPY " + results_table + "(asn, prefix, origin, received_from_asn, time)") +
                                   "FROM '" + file_name + "' WITH (FORMAT csv)";
     execute(sql);
@@ -430,7 +459,8 @@ void SQLQuerier::copy_results_to_db(std::string file_name) {
 
 /** Similar to copy_results_to_db, but for a single AS result which includes an AS_PATH column.
  */
-void SQLQuerier::copy_single_results_to_db(std::string file_name) {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::copy_single_results_to_db(std::string file_name) {
     std::string sql = std::string("COPY " + full_path_results_table + "(asn, prefix, origin, received_from_asn, time, as_path)") +
                                   "FROM '" + file_name + "' WITH (FORMAT csv)";
     execute(sql);
@@ -438,7 +468,8 @@ void SQLQuerier::copy_single_results_to_db(std::string file_name) {
 
 /** Takes a .csv filename and bulk copies all elements to the depref table.
  */
-void SQLQuerier::copy_depref_to_db(std::string file_name) {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::copy_depref_to_db(std::string file_name) {
     std::string sql = std::string("COPY " + depref_table + "(asn, prefix, origin, received_from_asn, time)") +
                                   "FROM '" + file_name + "' WITH (FORMAT csv)";
     execute(sql);
@@ -447,7 +478,8 @@ void SQLQuerier::copy_depref_to_db(std::string file_name) {
 
 /** Takes a .csv filename and bulk copies all elements to the inverse results table.
  */
-void SQLQuerier::copy_inverse_results_to_db(std::string file_name) {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::copy_inverse_results_to_db(std::string file_name) {
     std::string sql = std::string("COPY " + inverse_results_table + "(asn, prefix, origin)") +
                                   "FROM '" + file_name + "' WITH (FORMAT csv)";
     execute(sql);
@@ -456,9 +488,13 @@ void SQLQuerier::copy_inverse_results_to_db(std::string file_name) {
 
 /** Generate an index on the results table.
  */
-void SQLQuerier::create_results_index() {
+template <typename PrefixType>
+void SQLQuerier<PrefixType>::create_results_index() {
     // Version of postgres must support this
     std::string sql = std::string("CREATE INDEX ON " + results_table + " USING GIST(prefix inet_ops, origin)");
     BOOST_LOG_TRIVIAL(info) << "Generating index on results...";
     execute(sql, false);
 }
+
+template class SQLQuerier<>;
+template class SQLQuerier<uint128_t>;

--- a/src/SQLQueriers/SQLQuerier.cpp
+++ b/src/SQLQueriers/SQLQuerier.cpp
@@ -194,7 +194,7 @@ pqxx::result SQLQuerier::select_from_table(std::string table_name, int limit) {
  *
  * @param p The prefix for which we SELECT
  */
-pqxx::result SQLQuerier::select_prefix_count(Prefix<>* p) {
+pqxx::result SQLQuerier::select_prefix_count(Prefix* p) {
     std::string cidr = p->to_cidr();
     std::string sql = "SELECT COUNT(*) FROM " + announcements_table;
 
@@ -213,7 +213,7 @@ pqxx::result SQLQuerier::select_prefix_count(Prefix<>* p) {
  *
  * @param p The prefix for which we SELECT
  */
-pqxx::result SQLQuerier::select_prefix_ann(Prefix<>* p) {
+pqxx::result SQLQuerier::select_prefix_ann(Prefix* p) {
     std::string cidr = p->to_cidr();
     std::string sql = "SELECT host(prefix), netmask(prefix), as_path, origin, time FROM " + announcements_table;
 
@@ -231,7 +231,7 @@ pqxx::result SQLQuerier::select_prefix_ann(Prefix<>* p) {
  *
  * @param p The prefix defining the subnet
  */
-pqxx::result SQLQuerier::select_subnet_count(Prefix<>* p) {
+pqxx::result SQLQuerier::select_subnet_count(Prefix* p) {
     std::string cidr = p->to_cidr();
     std::string sql = "SELECT COUNT(*) FROM " + announcements_table;
 
@@ -249,7 +249,7 @@ pqxx::result SQLQuerier::select_subnet_count(Prefix<>* p) {
  *
  * @param p The prefix defining the subnet
  */
-pqxx::result SQLQuerier::select_subnet_ann(Prefix<>* p) {
+pqxx::result SQLQuerier::select_subnet_ann(Prefix* p) {
     std::string cidr = p->to_cidr();
     std::string sql = "SELECT host(prefix), netmask(prefix), as_path, origin, time FROM " + announcements_table;
 

--- a/src/SQLQueriers/SQLQuerier.cpp
+++ b/src/SQLQueriers/SQLQuerier.cpp
@@ -403,7 +403,7 @@ void SQLQuerier<PrefixType>::create_results_tbl() {
     std::string sql = std::string("CREATE UNLOGGED TABLE IF NOT EXISTS " + results_table + " (ann_id serial PRIMARY KEY,\
     */
     std::string sql = std::string("CREATE UNLOGGED TABLE IF NOT EXISTS " + results_table + " (\
-    asn bigint,prefix cidr, origin bigint, received_from_asn \
+    asn bigint,prefix inet, origin bigint, received_from_asn \
     bigint, time bigint); GRANT ALL ON TABLE " + results_table + " TO bgp_user;");
     BOOST_LOG_TRIVIAL(info) << "Creating results table...";
     execute(sql, false);
@@ -416,7 +416,7 @@ void SQLQuerier<PrefixType>::create_results_tbl() {
 template <typename PrefixType>
 void SQLQuerier<PrefixType>::create_full_path_results_tbl() {
     std::string sql = std::string("CREATE UNLOGGED TABLE IF NOT EXISTS " + full_path_results_table + " (\
-    asn bigint,prefix cidr, origin bigint, received_from_asn \
+    asn bigint,prefix inet, origin bigint, received_from_asn \
     bigint, time bigint, as_path bigint[]); GRANT ALL ON TABLE " + full_path_results_table + " TO bgp_user;");
     std::cout << "Creating full path results table..." << std::endl;
     execute(sql, false);
@@ -427,7 +427,7 @@ void SQLQuerier<PrefixType>::create_full_path_results_tbl() {
 template <typename PrefixType>
 void SQLQuerier<PrefixType>::create_depref_tbl() {
     std::string sql = std::string("CREATE UNLOGGED TABLE IF NOT EXISTS " + depref_table + " (\
-    asn bigint,prefix cidr, origin bigint, received_from_asn \
+    asn bigint,prefix inet, origin bigint, received_from_asn \
     bigint, time bigint); GRANT ALL ON TABLE " + depref_table + " TO bgp_user;");
     BOOST_LOG_TRIVIAL(info) << "Creating depref table...";
     execute(sql, false);
@@ -440,7 +440,7 @@ template <typename PrefixType>
 void SQLQuerier<PrefixType>::create_inverse_results_tbl() {
     std::string sql;
     sql = std::string("CREATE UNLOGGED TABLE IF NOT EXISTS ") + inverse_results_table + 
-    "(asn bigint,prefix cidr, origin bigint) ";
+    "(asn bigint,prefix inet, origin bigint) ";
     sql += ";";
     sql += "GRANT ALL ON TABLE " + inverse_results_table + " TO bgp_user;";
     BOOST_LOG_TRIVIAL(info) << "Creating inverse results table...";

--- a/src/Tests/ASGraphTest.cpp
+++ b/src/Tests/ASGraphTest.cpp
@@ -1,418 +1,418 @@
-// /*************************************************************************
-//  * This file is part of the BGP Extrapolator.
-//  *
-//  * Developed for the SIDR ROV Forecast.
-//  * This package includes software developed by the SIDR Project
-//  * (https://sidr.engr.uconn.edu/).
-//  * See the COPYRIGHT file at the top-level directory of this distribution
-//  * for details of code ownership.
-//  *
-//  * This program is free software: you can redistribute it and/or modify
-//  * it under the terms of the GNU General Public License as published by
-//  * the Free Software Foundation, either version 3 of the License, or
-//  * (at your option) any later version.
-//  *
-//  * This program is distributed in the hope that it will be useful,
-//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  * GNU General Public License for more details.
-//  *
-//  * You should have received a copy of the GNU General Public License
-//  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
-//  ************************************************************************/
+/*************************************************************************
+ * This file is part of the BGP Extrapolator.
+ *
+ * Developed for the SIDR ROV Forecast.
+ * This package includes software developed by the SIDR Project
+ * (https://sidr.engr.uconn.edu/).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ ************************************************************************/
 
-// #include <iostream>
-// #include <fstream>
+#include <iostream>
+#include <fstream>
 
-// #include "Graphs/ASGraph.h"
-// #include "ASes/AS.h"
-// #include "Graphs/RanGraph.h"
+#include "Graphs/ASGraph.h"
+#include "ASes/AS.h"
+#include "Graphs/RanGraph.h"
 
-// /** Unit tests for ASGraph.h and ASGraph.cpp
-//  */
+/** Unit tests for ASGraph.h and ASGraph.cpp
+ */
 
 
-// /** Test adding a AS relationship to graph by building this test graph.
-//  *  AS2 is a provider to AS1, which is a peer to AS3.
-//  *
-//  *  AS2
-//  *   |
-//  *   V
-//  *  AS1---AS3
-//  * 
-//  * @return true if successful, otherwise false.
-//  */
-// bool test_add_relationship(){
-//     ASGraph<> graph = ASGraph<>(false, false);
-//     graph.add_relationship(1, 2, AS_REL_PROVIDER);
-//     graph.add_relationship(2, 1, AS_REL_CUSTOMER);
-//     graph.add_relationship(1, 3, AS_REL_PEER);
-//     graph.add_relationship(3, 1, AS_REL_PEER);
-//     if (*graph.ases->find(1)->second->providers->find(2) != 2) {
-//         return false;
-//     }
-//     if (*graph.ases->find(1)->second->peers->find(3) != 3) {
-//         return false;
-//     }
-//     if (*graph.ases->find(2)->second->customers->find(1) != 1) {
-//         return false;
-//     }
-//     if (*graph.ases->find(3)->second->peers->find(1) != 1) {
-//         return false;
-//     }
-//     return true;
-// }
+/** Test adding a AS relationship to graph by building this test graph.
+ *  AS2 is a provider to AS1, which is a peer to AS3.
+ *
+ *  AS2
+ *   |
+ *   V
+ *  AS1---AS3
+ * 
+ * @return true if successful, otherwise false.
+ */
+bool test_add_relationship(){
+    ASGraph<> graph = ASGraph<>(false, false);
+    graph.add_relationship(1, 2, AS_REL_PROVIDER);
+    graph.add_relationship(2, 1, AS_REL_CUSTOMER);
+    graph.add_relationship(1, 3, AS_REL_PEER);
+    graph.add_relationship(3, 1, AS_REL_PEER);
+    if (*graph.ases->find(1)->second->providers->find(2) != 2) {
+        return false;
+    }
+    if (*graph.ases->find(1)->second->peers->find(3) != 3) {
+        return false;
+    }
+    if (*graph.ases->find(2)->second->customers->find(1) != 1) {
+        return false;
+    }
+    if (*graph.ases->find(3)->second->peers->find(1) != 1) {
+        return false;
+    }
+    return true;
+}
 
-// /** Test translating a ASN into it's supernode Identifier
-//  *
-//  * @return true if successful, otherwise false.
-//  */
-// bool test_translate_asn(){
-//     ASGraph<> graph = ASGraph<>(false, false);
-//     // add_relation(Target, Neighber, Relation of neighbor to target)
-//     // Cycle 
-//     graph.add_relationship(2, 1, AS_REL_PROVIDER);
-//     graph.add_relationship(1, 2, AS_REL_CUSTOMER);
-//     graph.add_relationship(1, 3, AS_REL_PROVIDER);
-//     graph.add_relationship(3, 1, AS_REL_CUSTOMER);
-//     graph.add_relationship(3, 2, AS_REL_PROVIDER);
-//     graph.add_relationship(2, 3, AS_REL_CUSTOMER);
-//     // Customer
-//     graph.add_relationship(5, 3, AS_REL_PROVIDER);
-//     graph.add_relationship(3, 5, AS_REL_CUSTOMER);
-//     graph.add_relationship(6, 3, AS_REL_PROVIDER);
-//     graph.add_relationship(3, 6, AS_REL_CUSTOMER);
-//     // Peer
-//     graph.add_relationship(4, 3, AS_REL_PEER);
-//     graph.add_relationship(3, 4, AS_REL_PEER);
-//     graph.tarjan();
-//     graph.combine_components();
+/** Test translating a ASN into it's supernode Identifier
+ *
+ * @return true if successful, otherwise false.
+ */
+bool test_translate_asn(){
+    ASGraph<> graph = ASGraph<>(false, false);
+    // add_relation(Target, Neighber, Relation of neighbor to target)
+    // Cycle 
+    graph.add_relationship(2, 1, AS_REL_PROVIDER);
+    graph.add_relationship(1, 2, AS_REL_CUSTOMER);
+    graph.add_relationship(1, 3, AS_REL_PROVIDER);
+    graph.add_relationship(3, 1, AS_REL_CUSTOMER);
+    graph.add_relationship(3, 2, AS_REL_PROVIDER);
+    graph.add_relationship(2, 3, AS_REL_CUSTOMER);
+    // Customer
+    graph.add_relationship(5, 3, AS_REL_PROVIDER);
+    graph.add_relationship(3, 5, AS_REL_CUSTOMER);
+    graph.add_relationship(6, 3, AS_REL_PROVIDER);
+    graph.add_relationship(3, 6, AS_REL_CUSTOMER);
+    // Peer
+    graph.add_relationship(4, 3, AS_REL_PEER);
+    graph.add_relationship(3, 4, AS_REL_PEER);
+    graph.tarjan();
+    graph.combine_components();
 
-//     if (graph.translate_asn(1) != 1 ||
-//         graph.translate_asn(2) != 1 ||
-//         graph.translate_asn(3) != 1)
-//         return false;
-//     if (graph.translate_asn(4) != 4 ||
-//         graph.translate_asn(5) != 5 ||
-//         graph.translate_asn(6) != 6)
-//         return false;
-//     return true;
-// }
+    if (graph.translate_asn(1) != 1 ||
+        graph.translate_asn(2) != 1 ||
+        graph.translate_asn(3) != 1)
+        return false;
+    if (graph.translate_asn(4) != 4 ||
+        graph.translate_asn(5) != 5 ||
+        graph.translate_asn(6) != 6)
+        return false;
+    return true;
+}
 
-// /** Test assignment of ranks to each AS in the graph. 
-//  *  Horizontal lines are peer relationships, vertical lines are customer-provider
-//  * 
-//  *    1
-//  *   / \
-//  *  2   3--4
-//  *     / \
-//  *    5   6
-//  *
-//  * @return true if successful, otherwise false.
-//  */
-// bool test_decide_ranks(){
-//     ASGraph<> graph = ASGraph<>(false, false);
-//     graph.add_relationship(2, 1, AS_REL_PROVIDER);
-//     graph.add_relationship(1, 2, AS_REL_CUSTOMER);
-//     graph.add_relationship(3, 1, AS_REL_PROVIDER);
-//     graph.add_relationship(1, 3, AS_REL_CUSTOMER);
-//     graph.add_relationship(5, 3, AS_REL_PROVIDER);
-//     graph.add_relationship(3, 5, AS_REL_CUSTOMER);
-//     graph.add_relationship(6, 3, AS_REL_PROVIDER);
-//     graph.add_relationship(3, 6, AS_REL_CUSTOMER);
-//     graph.add_relationship(4, 3, AS_REL_PEER);
-//     graph.add_relationship(3, 4, AS_REL_PEER);
-//     graph.decide_ranks();
-//     int num_systems = 6;
-//     int acc = 0;
-//     for (auto set : *graph.ases_by_rank) {
-//         acc += set->size();
-//     }
-//     if (acc != num_systems) {
-//         std::cerr << "Number of ASes in ases_by_rank != total number of ASes." << std::endl;
-//         return false;
-//     }
-//     if (graph.ases->find(1)->second->rank == 2 &&
-//         graph.ases->find(2)->second->rank == 0 &&
-//         graph.ases->find(3)->second->rank == 1 &&
-//         graph.ases->find(4)->second->rank == 0 &&
-//         graph.ases->find(5)->second->rank == 0 &&
-//         graph.ases->find(6)->second->rank == 0) {
-//         return true;
-//     }
-//     return false;
-// }
+/** Test assignment of ranks to each AS in the graph. 
+ *  Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *   / \
+ *  2   3--4
+ *     / \
+ *    5   6
+ *
+ * @return true if successful, otherwise false.
+ */
+bool test_decide_ranks(){
+    ASGraph<> graph = ASGraph<>(false, false);
+    graph.add_relationship(2, 1, AS_REL_PROVIDER);
+    graph.add_relationship(1, 2, AS_REL_CUSTOMER);
+    graph.add_relationship(3, 1, AS_REL_PROVIDER);
+    graph.add_relationship(1, 3, AS_REL_CUSTOMER);
+    graph.add_relationship(5, 3, AS_REL_PROVIDER);
+    graph.add_relationship(3, 5, AS_REL_CUSTOMER);
+    graph.add_relationship(6, 3, AS_REL_PROVIDER);
+    graph.add_relationship(3, 6, AS_REL_CUSTOMER);
+    graph.add_relationship(4, 3, AS_REL_PEER);
+    graph.add_relationship(3, 4, AS_REL_PEER);
+    graph.decide_ranks();
+    int num_systems = 6;
+    int acc = 0;
+    for (auto set : *graph.ases_by_rank) {
+        acc += set->size();
+    }
+    if (acc != num_systems) {
+        std::cerr << "Number of ASes in ases_by_rank != total number of ASes." << std::endl;
+        return false;
+    }
+    if (graph.ases->find(1)->second->rank == 2 &&
+        graph.ases->find(2)->second->rank == 0 &&
+        graph.ases->find(3)->second->rank == 1 &&
+        graph.ases->find(4)->second->rank == 0 &&
+        graph.ases->find(5)->second->rank == 0 &&
+        graph.ases->find(6)->second->rank == 0) {
+        return true;
+    }
+    return false;
+}
 
-// /** Test removing stub ASes from the graph. 
-//  * 
-//  *    1
-//  *   / \
-//  *  2   3--4
-//  *     / \
-//  *    5   6
-//  *
-//  * @return true if successful, otherwise false.
-//  */
-// bool test_remove_stubs(){
-//     ASGraph<> graph = ASGraph<>(false, false);
-//     SQLQuerier *querier = new SQLQuerier("mrt_announcements", "test_results", "test_results", "test_results_d");
-//     graph.add_relationship(2, 1, AS_REL_PROVIDER);
-//     graph.add_relationship(1, 2, AS_REL_CUSTOMER);
-//     graph.add_relationship(3, 1, AS_REL_PROVIDER);
-//     graph.add_relationship(1, 3, AS_REL_CUSTOMER);
-//     graph.add_relationship(5, 3, AS_REL_PROVIDER);
-//     graph.add_relationship(3, 5, AS_REL_CUSTOMER);
-//     graph.add_relationship(6, 3, AS_REL_PROVIDER);
-//     graph.add_relationship(3, 6, AS_REL_CUSTOMER);
-//     graph.add_relationship(4, 3, AS_REL_PEER);
-//     graph.add_relationship(3, 4, AS_REL_PEER);
-//     graph.remove_stubs(querier);
-//     delete querier;
-//     // Stub removal
-//     if (graph.ases->find(2) != graph.ases->end() ||
-//         graph.ases->find(5) != graph.ases->end() ||
-//         graph.ases->find(6) != graph.ases->end()) {
-//         std::cerr << "Failed stubs removal check." << std::endl;
-//         return false;
-//     }
-//     // Stub translation
-//     if (graph.translate_asn(2) != 1 ||
-//         graph.translate_asn(5) != 3 ||
-//         graph.translate_asn(6) != 3) {
-//         std::cerr << "Failed stubs translation check." << std::endl;
-//         return false;
-//     }
-//     return true;
-// }
+/** Test removing stub ASes from the graph. 
+ * 
+ *    1
+ *   / \
+ *  2   3--4
+ *     / \
+ *    5   6
+ *
+ * @return true if successful, otherwise false.
+ */
+bool test_remove_stubs(){
+    ASGraph<> graph = ASGraph<>(false, false);
+    SQLQuerier<> *querier = new SQLQuerier<>("mrt_announcements", "test_results", "test_results", "test_results_d");
+    graph.add_relationship(2, 1, AS_REL_PROVIDER);
+    graph.add_relationship(1, 2, AS_REL_CUSTOMER);
+    graph.add_relationship(3, 1, AS_REL_PROVIDER);
+    graph.add_relationship(1, 3, AS_REL_CUSTOMER);
+    graph.add_relationship(5, 3, AS_REL_PROVIDER);
+    graph.add_relationship(3, 5, AS_REL_CUSTOMER);
+    graph.add_relationship(6, 3, AS_REL_PROVIDER);
+    graph.add_relationship(3, 6, AS_REL_CUSTOMER);
+    graph.add_relationship(4, 3, AS_REL_PEER);
+    graph.add_relationship(3, 4, AS_REL_PEER);
+    graph.remove_stubs(querier);
+    delete querier;
+    // Stub removal
+    if (graph.ases->find(2) != graph.ases->end() ||
+        graph.ases->find(5) != graph.ases->end() ||
+        graph.ases->find(6) != graph.ases->end()) {
+        std::cerr << "Failed stubs removal check." << std::endl;
+        return false;
+    }
+    // Stub translation
+    if (graph.translate_asn(2) != 1 ||
+        graph.translate_asn(5) != 3 ||
+        graph.translate_asn(6) != 3) {
+        std::cerr << "Failed stubs translation check." << std::endl;
+        return false;
+    }
+    return true;
+}
 
-// /** Test the Tarjan algorithm for detecting strongly connected components.
-//  * Horizontal lines are peer relationships, vertical lines are customer-provider
-//  * 
-//  *    1
-//  *   / \
-//  *  2<- 3--4
-//  *     / \
-//  *    5   6
-//  *
-//  * @return true if successful, otherwise false.
-//  */
-// bool test_tarjan(){ // includes tarjan_helper()
-//     ASGraph<> graph = ASGraph<>(false, false);
-//     // Cycle 
-//     graph.add_relationship(2, 1, AS_REL_PROVIDER);
-//     graph.add_relationship(1, 2, AS_REL_CUSTOMER);
-//     graph.add_relationship(1, 3, AS_REL_PROVIDER);
-//     graph.add_relationship(3, 1, AS_REL_CUSTOMER);
-//     graph.add_relationship(3, 2, AS_REL_PROVIDER);
-//     graph.add_relationship(2, 3, AS_REL_CUSTOMER);
-//     // Customer
-//     graph.add_relationship(5, 3, AS_REL_PROVIDER);
-//     graph.add_relationship(3, 5, AS_REL_CUSTOMER);
-//     graph.add_relationship(6, 3, AS_REL_PROVIDER);
-//     graph.add_relationship(3, 6, AS_REL_CUSTOMER);
-//     // Peer
-//     graph.add_relationship(4, 3, AS_REL_PEER);
-//     graph.add_relationship(3, 4, AS_REL_PEER);
-//     graph.tarjan();
-//     if (graph.components->size() != 4) {
-//         return false;
-//     }
-//     // Verify the cycle was detected
-//     for (auto const& c : *graph.components) {
-//         if (c->size() > 1 && c->size() != 3)
-//             return false;
-//     }   
+/** Test the Tarjan algorithm for detecting strongly connected components.
+ * Horizontal lines are peer relationships, vertical lines are customer-provider
+ * 
+ *    1
+ *   / \
+ *  2<- 3--4
+ *     / \
+ *    5   6
+ *
+ * @return true if successful, otherwise false.
+ */
+bool test_tarjan(){ // includes tarjan_helper()
+    ASGraph<> graph = ASGraph<>(false, false);
+    // Cycle 
+    graph.add_relationship(2, 1, AS_REL_PROVIDER);
+    graph.add_relationship(1, 2, AS_REL_CUSTOMER);
+    graph.add_relationship(1, 3, AS_REL_PROVIDER);
+    graph.add_relationship(3, 1, AS_REL_CUSTOMER);
+    graph.add_relationship(3, 2, AS_REL_PROVIDER);
+    graph.add_relationship(2, 3, AS_REL_CUSTOMER);
+    // Customer
+    graph.add_relationship(5, 3, AS_REL_PROVIDER);
+    graph.add_relationship(3, 5, AS_REL_CUSTOMER);
+    graph.add_relationship(6, 3, AS_REL_PROVIDER);
+    graph.add_relationship(3, 6, AS_REL_CUSTOMER);
+    // Peer
+    graph.add_relationship(4, 3, AS_REL_PEER);
+    graph.add_relationship(3, 4, AS_REL_PEER);
+    graph.tarjan();
+    if (graph.components->size() != 4) {
+        return false;
+    }
+    // Verify the cycle was detected
+    for (auto const& c : *graph.components) {
+        if (c->size() > 1 && c->size() != 3)
+            return false;
+    }   
      
-//     // Multi supernode test
-//     ASGraph<> graph2 = ASGraph<>(false, false);
-//     // Cycle 10->11->12->10
-//     graph2.add_relationship(11, 10, AS_REL_PROVIDER);
-//     graph2.add_relationship(10, 11, AS_REL_CUSTOMER);
-//     graph2.add_relationship(12, 11, AS_REL_PROVIDER);
-//     graph2.add_relationship(11, 12, AS_REL_CUSTOMER);
-//     graph2.add_relationship(10, 12, AS_REL_PROVIDER);
-//     graph2.add_relationship(12, 10, AS_REL_CUSTOMER);
-//     // Cycle 13->14->15->13
-//     graph2.add_relationship(14, 13, AS_REL_PROVIDER);
-//     graph2.add_relationship(13, 14, AS_REL_CUSTOMER);
-//     graph2.add_relationship(15, 14, AS_REL_PROVIDER);
-//     graph2.add_relationship(14, 15, AS_REL_CUSTOMER);
-//     graph2.add_relationship(13, 15, AS_REL_PROVIDER);
-//     graph2.add_relationship(15, 13, AS_REL_CUSTOMER);
-//     // Peer
-//     graph2.add_relationship(11, 14, AS_REL_PEER);
-//     graph2.add_relationship(14, 11, AS_REL_PEER);
-//     graph2.tarjan();
+    // Multi supernode test
+    ASGraph<> graph2 = ASGraph<>(false, false);
+    // Cycle 10->11->12->10
+    graph2.add_relationship(11, 10, AS_REL_PROVIDER);
+    graph2.add_relationship(10, 11, AS_REL_CUSTOMER);
+    graph2.add_relationship(12, 11, AS_REL_PROVIDER);
+    graph2.add_relationship(11, 12, AS_REL_CUSTOMER);
+    graph2.add_relationship(10, 12, AS_REL_PROVIDER);
+    graph2.add_relationship(12, 10, AS_REL_CUSTOMER);
+    // Cycle 13->14->15->13
+    graph2.add_relationship(14, 13, AS_REL_PROVIDER);
+    graph2.add_relationship(13, 14, AS_REL_CUSTOMER);
+    graph2.add_relationship(15, 14, AS_REL_PROVIDER);
+    graph2.add_relationship(14, 15, AS_REL_CUSTOMER);
+    graph2.add_relationship(13, 15, AS_REL_PROVIDER);
+    graph2.add_relationship(15, 13, AS_REL_CUSTOMER);
+    // Peer
+    graph2.add_relationship(11, 14, AS_REL_PEER);
+    graph2.add_relationship(14, 11, AS_REL_PEER);
+    graph2.tarjan();
     
-//     if (graph2.components->size() != 2) {
-//         return false;
-//     }
-//     // Verify the cycle was detected
-//     for (auto const& c : *graph2.components) {
-//         if (c->size() > 1 && c->size() != 3)
-//             return false;
-//     }
+    if (graph2.components->size() != 2) {
+        return false;
+    }
+    // Verify the cycle was detected
+    for (auto const& c : *graph2.components) {
+        if (c->size() > 1 && c->size() != 3)
+            return false;
+    }
    
-//     srand(time(NULL));
-//     for (int i = 0; i < 100; i++) {
-//         ASGraph<> *graph3;
-//         graph3 = ran_graph(100, 100);
-//         graph3->tarjan();
+    srand(time(NULL));
+    for (int i = 0; i < 100; i++) {
+        ASGraph<> *graph3;
+        graph3 = ran_graph(100, 100);
+        graph3->tarjan();
 
-//         bool tarjan_cyclic = false;
-//         bool cyclic = is_cyclic(graph3);
-//         if (cyclic) {
-//             for (auto &component : *graph3->components) {
-//                if (component->size() > 1) {
-//                   tarjan_cyclic = true;
-//                }
-//             }
-//             if (tarjan_cyclic != cyclic) {
-//                 return false;
-//             }
-//         } 
-//         //graph3->combine_components();
-//         // if this terminates, there are no cycles in the graph
-//         //graph3->decide_ranks();
-//         delete graph3;
-//     }
-//     return true;
-// }
+        bool tarjan_cyclic = false;
+        bool cyclic = is_cyclic(graph3);
+        if (cyclic) {
+            for (auto &component : *graph3->components) {
+               if (component->size() > 1) {
+                  tarjan_cyclic = true;
+               }
+            }
+            if (tarjan_cyclic != cyclic) {
+                return false;
+            }
+        } 
+        //graph3->combine_components();
+        // if this terminates, there are no cycles in the graph
+        //graph3->decide_ranks();
+        delete graph3;
+    }
+    return true;
+}
 
-// /** Test the combining of strongly connected components into supernodes.
-//  * 
-//  *        7
-//  *        |
-//  *        1
-//  *     /  |  \
-//  * 8--2 ->3-- 4
-//  *       / \
-//  *      5   6
-//  *
-//  *
-//  * @return true if successful, otherwise false.
-//  */
-// bool test_combine_components(){
-//     ASGraph<> graph = ASGraph<>(false, false);
-//     // Cycle 1->2->3->1
-//     graph.add_relationship(2, 1, AS_REL_PROVIDER);
-//     graph.add_relationship(1, 2, AS_REL_CUSTOMER);
-//     graph.add_relationship(3, 2, AS_REL_PROVIDER);
-//     graph.add_relationship(2, 3, AS_REL_CUSTOMER);
-//     graph.add_relationship(1, 3, AS_REL_PROVIDER);
-//     graph.add_relationship(3, 1, AS_REL_CUSTOMER);
-//     // Provider
-//     graph.add_relationship(1, 7, AS_REL_PROVIDER);
-//     graph.add_relationship(7, 1, AS_REL_CUSTOMER);
-//     graph.add_relationship(4, 1, AS_REL_PROVIDER);
-//     graph.add_relationship(1, 4, AS_REL_CUSTOMER);
-//     // Customer
-//     graph.add_relationship(5, 3, AS_REL_PROVIDER);
-//     graph.add_relationship(3, 5, AS_REL_CUSTOMER);
-//     graph.add_relationship(6, 3, AS_REL_PROVIDER);
-//     graph.add_relationship(3, 6, AS_REL_CUSTOMER);
-//     // Peer
-//     graph.add_relationship(4, 3, AS_REL_PEER);
-//     graph.add_relationship(3, 4, AS_REL_PEER);
-//     graph.add_relationship(8, 2, AS_REL_PEER);
-//     graph.add_relationship(2, 8, AS_REL_PEER);
+/** Test the combining of strongly connected components into supernodes.
+ * 
+ *        7
+ *        |
+ *        1
+ *     /  |  \
+ * 8--2 ->3-- 4
+ *       / \
+ *      5   6
+ *
+ *
+ * @return true if successful, otherwise false.
+ */
+bool test_combine_components(){
+    ASGraph<> graph = ASGraph<>(false, false);
+    // Cycle 1->2->3->1
+    graph.add_relationship(2, 1, AS_REL_PROVIDER);
+    graph.add_relationship(1, 2, AS_REL_CUSTOMER);
+    graph.add_relationship(3, 2, AS_REL_PROVIDER);
+    graph.add_relationship(2, 3, AS_REL_CUSTOMER);
+    graph.add_relationship(1, 3, AS_REL_PROVIDER);
+    graph.add_relationship(3, 1, AS_REL_CUSTOMER);
+    // Provider
+    graph.add_relationship(1, 7, AS_REL_PROVIDER);
+    graph.add_relationship(7, 1, AS_REL_CUSTOMER);
+    graph.add_relationship(4, 1, AS_REL_PROVIDER);
+    graph.add_relationship(1, 4, AS_REL_CUSTOMER);
+    // Customer
+    graph.add_relationship(5, 3, AS_REL_PROVIDER);
+    graph.add_relationship(3, 5, AS_REL_CUSTOMER);
+    graph.add_relationship(6, 3, AS_REL_PROVIDER);
+    graph.add_relationship(3, 6, AS_REL_CUSTOMER);
+    // Peer
+    graph.add_relationship(4, 3, AS_REL_PEER);
+    graph.add_relationship(3, 4, AS_REL_PEER);
+    graph.add_relationship(8, 2, AS_REL_PEER);
+    graph.add_relationship(2, 8, AS_REL_PEER);
 
-//     graph.tarjan();
-//     graph.combine_components();
-//     // Check for the supernode
-//     if (graph.component_translation->size() != 3) {
-//         std::cerr << "Incorrect translation size." << std::endl;
-//         return false;
-//     }
-//     // Verify lowest ASN is identifier
-//     for (auto c : *graph.component_translation) {
-//         if (c.second != 1) {
-//             std::cerr << "Incorrect translation ID for supernode." << std::endl;
-//             return false;
-//         }
-//     }
+    graph.tarjan();
+    graph.combine_components();
+    // Check for the supernode
+    if (graph.component_translation->size() != 3) {
+        std::cerr << "Incorrect translation size." << std::endl;
+        return false;
+    }
+    // Verify lowest ASN is identifier
+    for (auto c : *graph.component_translation) {
+        if (c.second != 1) {
+            std::cerr << "Incorrect translation ID for supernode." << std::endl;
+            return false;
+        }
+    }
 
-//     // Find supernode AS
-//     auto SCC = graph.ases->find(1);
-//     AS<> *supernode = SCC->second;
-//     // Check supernode providers
-//     if (supernode->providers->find(7) == supernode->providers->end()) {
-//         std::cerr << "Incorrect supernode provider set." << std::endl;
-//         return false;
-//     }
-//     // Check supernode customers
-//     if (supernode->customers->find(4) == supernode->customers->end() ||
-//         supernode->customers->find(5) == supernode->customers->end() ||
-//         supernode->customers->find(6) == supernode->customers->end()) {
-//         std::cerr << "Incorrect supernode customer set." << std::endl;
-//         return false;
-//     }
-//     // Check supernode peers
-//     if (supernode->peers->find(8) == supernode->peers->end()) {
-//         std::cerr << "Incorrect supernode peer set." << std::endl;
-//         return false;
-//     }
-//     // Check supernode peers
-//     if (supernode->peers->find(4) != supernode->peers->end()) {
-//         std::cerr << "Incorrect supernode peer-customer override." << std::endl;
-//         return false;
-//     }
+    // Find supernode AS
+    auto SCC = graph.ases->find(1);
+    AS<> *supernode = SCC->second;
+    // Check supernode providers
+    if (supernode->providers->find(7) == supernode->providers->end()) {
+        std::cerr << "Incorrect supernode provider set." << std::endl;
+        return false;
+    }
+    // Check supernode customers
+    if (supernode->customers->find(4) == supernode->customers->end() ||
+        supernode->customers->find(5) == supernode->customers->end() ||
+        supernode->customers->find(6) == supernode->customers->end()) {
+        std::cerr << "Incorrect supernode customer set." << std::endl;
+        return false;
+    }
+    // Check supernode peers
+    if (supernode->peers->find(8) == supernode->peers->end()) {
+        std::cerr << "Incorrect supernode peer set." << std::endl;
+        return false;
+    }
+    // Check supernode peers
+    if (supernode->peers->find(4) != supernode->peers->end()) {
+        std::cerr << "Incorrect supernode peer-customer override." << std::endl;
+        return false;
+    }
 
 
-//     // Multi supernode test
-//     ASGraph<> graph2 = ASGraph<>(false, false);
-//     // Cycle 10->11->12->10
-//     graph2.add_relationship(11, 10, AS_REL_PROVIDER);
-//     graph2.add_relationship(10, 11, AS_REL_CUSTOMER);
-//     graph2.add_relationship(12, 11, AS_REL_PROVIDER);
-//     graph2.add_relationship(11, 12, AS_REL_CUSTOMER);
-//     graph2.add_relationship(10, 12, AS_REL_PROVIDER);
-//     graph2.add_relationship(12, 10, AS_REL_CUSTOMER);
-//     // Cycle 13->14->15->13
-//     graph2.add_relationship(14, 13, AS_REL_PROVIDER);
-//     graph2.add_relationship(13, 14, AS_REL_CUSTOMER);
-//     graph2.add_relationship(15, 14, AS_REL_PROVIDER);
-//     graph2.add_relationship(14, 15, AS_REL_CUSTOMER);
-//     graph2.add_relationship(13, 15, AS_REL_PROVIDER);
-//     graph2.add_relationship(15, 13, AS_REL_CUSTOMER);
-//     // Peer
-//     graph2.add_relationship(11, 14, AS_REL_PEER);
-//     graph2.add_relationship(14, 11, AS_REL_PEER);
+    // Multi supernode test
+    ASGraph<> graph2 = ASGraph<>(false, false);
+    // Cycle 10->11->12->10
+    graph2.add_relationship(11, 10, AS_REL_PROVIDER);
+    graph2.add_relationship(10, 11, AS_REL_CUSTOMER);
+    graph2.add_relationship(12, 11, AS_REL_PROVIDER);
+    graph2.add_relationship(11, 12, AS_REL_CUSTOMER);
+    graph2.add_relationship(10, 12, AS_REL_PROVIDER);
+    graph2.add_relationship(12, 10, AS_REL_CUSTOMER);
+    // Cycle 13->14->15->13
+    graph2.add_relationship(14, 13, AS_REL_PROVIDER);
+    graph2.add_relationship(13, 14, AS_REL_CUSTOMER);
+    graph2.add_relationship(15, 14, AS_REL_PROVIDER);
+    graph2.add_relationship(14, 15, AS_REL_CUSTOMER);
+    graph2.add_relationship(13, 15, AS_REL_PROVIDER);
+    graph2.add_relationship(15, 13, AS_REL_CUSTOMER);
+    // Peer
+    graph2.add_relationship(11, 14, AS_REL_PEER);
+    graph2.add_relationship(14, 11, AS_REL_PEER);
     
-//     graph2.add_relationship(12, 14, AS_REL_PEER);
-//     graph2.add_relationship(14, 12, AS_REL_PEER);
+    graph2.add_relationship(12, 14, AS_REL_PEER);
+    graph2.add_relationship(14, 12, AS_REL_PEER);
     
-//     graph2.add_relationship(12, 15, AS_REL_PEER);
-//     graph2.add_relationship(15, 12, AS_REL_PEER);
+    graph2.add_relationship(12, 15, AS_REL_PEER);
+    graph2.add_relationship(15, 12, AS_REL_PEER);
 
-//     // Provider
-//     //graph2.add_relationship(11, 15, AS_REL_PROVIDER);
-//     //graph2.add_relationship(15, 11, AS_REL_CUSTOMER);
+    // Provider
+    //graph2.add_relationship(11, 15, AS_REL_PROVIDER);
+    //graph2.add_relationship(15, 11, AS_REL_CUSTOMER);
 
-//     graph2.tarjan();
-//     graph2.combine_components();
+    graph2.tarjan();
+    graph2.combine_components();
 
-//     if (graph2.component_translation->size() != 6) {
-//         std::cerr << "Incorrect translation size: " << std::endl;
-//         return false;
-//     }
+    if (graph2.component_translation->size() != 6) {
+        std::cerr << "Incorrect translation size: " << std::endl;
+        return false;
+    }
 
-//     // Find supernode AS
-//     //std::cout << graph2 << std::endl;
-//     auto SCC1 = graph2.ases->find(10);
-//     auto SCC2 = graph2.ases->find(13);
-//     AS<> *supernode1 = SCC1->second;
-//     AS<> *supernode2 = SCC2->second;
-//     // Check supernode providers
-//     if (supernode1->providers->find(13) != supernode1->providers->end()) {
-//         std::cerr << "Incorrect supernode provider set." << std::endl;
-//         return false;
-//     }
-//     // Check supernode peers
-//     if (supernode1->peers->find(13) == supernode1->peers->end() ||
-//         supernode2->peers->find(10) == supernode2->peers->end()) {
-//         std::cerr << "Incorrect supernode peer set." << std::endl;
-//         return false;
-//     }
-//     return true;
-// }
+    // Find supernode AS
+    //std::cout << graph2 << std::endl;
+    auto SCC1 = graph2.ases->find(10);
+    auto SCC2 = graph2.ases->find(13);
+    AS<> *supernode1 = SCC1->second;
+    AS<> *supernode2 = SCC2->second;
+    // Check supernode providers
+    if (supernode1->providers->find(13) != supernode1->providers->end()) {
+        std::cerr << "Incorrect supernode provider set." << std::endl;
+        return false;
+    }
+    // Check supernode peers
+    if (supernode1->peers->find(13) == supernode1->peers->end() ||
+        supernode2->peers->find(10) == supernode2->peers->end()) {
+        std::cerr << "Incorrect supernode peer set." << std::endl;
+        return false;
+    }
+    return true;
+}

--- a/src/Tests/ASGraphTest.cpp
+++ b/src/Tests/ASGraphTest.cpp
@@ -1,418 +1,418 @@
-/*************************************************************************
- * This file is part of the BGP Extrapolator.
- *
- * Developed for the SIDR ROV Forecast.
- * This package includes software developed by the SIDR Project
- * (https://sidr.engr.uconn.edu/).
- * See the COPYRIGHT file at the top-level directory of this distribution
- * for details of code ownership.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- ************************************************************************/
+// /*************************************************************************
+//  * This file is part of the BGP Extrapolator.
+//  *
+//  * Developed for the SIDR ROV Forecast.
+//  * This package includes software developed by the SIDR Project
+//  * (https://sidr.engr.uconn.edu/).
+//  * See the COPYRIGHT file at the top-level directory of this distribution
+//  * for details of code ownership.
+//  *
+//  * This program is free software: you can redistribute it and/or modify
+//  * it under the terms of the GNU General Public License as published by
+//  * the Free Software Foundation, either version 3 of the License, or
+//  * (at your option) any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful,
+//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  * GNU General Public License for more details.
+//  *
+//  * You should have received a copy of the GNU General Public License
+//  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//  ************************************************************************/
 
-#include <iostream>
-#include <fstream>
+// #include <iostream>
+// #include <fstream>
 
-#include "Graphs/ASGraph.h"
-#include "ASes/AS.h"
-#include "Graphs/RanGraph.h"
+// #include "Graphs/ASGraph.h"
+// #include "ASes/AS.h"
+// #include "Graphs/RanGraph.h"
 
-/** Unit tests for ASGraph.h and ASGraph.cpp
- */
+// /** Unit tests for ASGraph.h and ASGraph.cpp
+//  */
 
 
-/** Test adding a AS relationship to graph by building this test graph.
- *  AS2 is a provider to AS1, which is a peer to AS3.
- *
- *  AS2
- *   |
- *   V
- *  AS1---AS3
- * 
- * @return true if successful, otherwise false.
- */
-bool test_add_relationship(){
-    ASGraph graph = ASGraph(false, false);
-    graph.add_relationship(1, 2, AS_REL_PROVIDER);
-    graph.add_relationship(2, 1, AS_REL_CUSTOMER);
-    graph.add_relationship(1, 3, AS_REL_PEER);
-    graph.add_relationship(3, 1, AS_REL_PEER);
-    if (*graph.ases->find(1)->second->providers->find(2) != 2) {
-        return false;
-    }
-    if (*graph.ases->find(1)->second->peers->find(3) != 3) {
-        return false;
-    }
-    if (*graph.ases->find(2)->second->customers->find(1) != 1) {
-        return false;
-    }
-    if (*graph.ases->find(3)->second->peers->find(1) != 1) {
-        return false;
-    }
-    return true;
-}
+// /** Test adding a AS relationship to graph by building this test graph.
+//  *  AS2 is a provider to AS1, which is a peer to AS3.
+//  *
+//  *  AS2
+//  *   |
+//  *   V
+//  *  AS1---AS3
+//  * 
+//  * @return true if successful, otherwise false.
+//  */
+// bool test_add_relationship(){
+//     ASGraph<> graph = ASGraph<>(false, false);
+//     graph.add_relationship(1, 2, AS_REL_PROVIDER);
+//     graph.add_relationship(2, 1, AS_REL_CUSTOMER);
+//     graph.add_relationship(1, 3, AS_REL_PEER);
+//     graph.add_relationship(3, 1, AS_REL_PEER);
+//     if (*graph.ases->find(1)->second->providers->find(2) != 2) {
+//         return false;
+//     }
+//     if (*graph.ases->find(1)->second->peers->find(3) != 3) {
+//         return false;
+//     }
+//     if (*graph.ases->find(2)->second->customers->find(1) != 1) {
+//         return false;
+//     }
+//     if (*graph.ases->find(3)->second->peers->find(1) != 1) {
+//         return false;
+//     }
+//     return true;
+// }
 
-/** Test translating a ASN into it's supernode Identifier
- *
- * @return true if successful, otherwise false.
- */
-bool test_translate_asn(){
-    ASGraph graph = ASGraph(false, false);
-    // add_relation(Target, Neighber, Relation of neighbor to target)
-    // Cycle 
-    graph.add_relationship(2, 1, AS_REL_PROVIDER);
-    graph.add_relationship(1, 2, AS_REL_CUSTOMER);
-    graph.add_relationship(1, 3, AS_REL_PROVIDER);
-    graph.add_relationship(3, 1, AS_REL_CUSTOMER);
-    graph.add_relationship(3, 2, AS_REL_PROVIDER);
-    graph.add_relationship(2, 3, AS_REL_CUSTOMER);
-    // Customer
-    graph.add_relationship(5, 3, AS_REL_PROVIDER);
-    graph.add_relationship(3, 5, AS_REL_CUSTOMER);
-    graph.add_relationship(6, 3, AS_REL_PROVIDER);
-    graph.add_relationship(3, 6, AS_REL_CUSTOMER);
-    // Peer
-    graph.add_relationship(4, 3, AS_REL_PEER);
-    graph.add_relationship(3, 4, AS_REL_PEER);
-    graph.tarjan();
-    graph.combine_components();
+// /** Test translating a ASN into it's supernode Identifier
+//  *
+//  * @return true if successful, otherwise false.
+//  */
+// bool test_translate_asn(){
+//     ASGraph<> graph = ASGraph<>(false, false);
+//     // add_relation(Target, Neighber, Relation of neighbor to target)
+//     // Cycle 
+//     graph.add_relationship(2, 1, AS_REL_PROVIDER);
+//     graph.add_relationship(1, 2, AS_REL_CUSTOMER);
+//     graph.add_relationship(1, 3, AS_REL_PROVIDER);
+//     graph.add_relationship(3, 1, AS_REL_CUSTOMER);
+//     graph.add_relationship(3, 2, AS_REL_PROVIDER);
+//     graph.add_relationship(2, 3, AS_REL_CUSTOMER);
+//     // Customer
+//     graph.add_relationship(5, 3, AS_REL_PROVIDER);
+//     graph.add_relationship(3, 5, AS_REL_CUSTOMER);
+//     graph.add_relationship(6, 3, AS_REL_PROVIDER);
+//     graph.add_relationship(3, 6, AS_REL_CUSTOMER);
+//     // Peer
+//     graph.add_relationship(4, 3, AS_REL_PEER);
+//     graph.add_relationship(3, 4, AS_REL_PEER);
+//     graph.tarjan();
+//     graph.combine_components();
 
-    if (graph.translate_asn(1) != 1 ||
-        graph.translate_asn(2) != 1 ||
-        graph.translate_asn(3) != 1)
-        return false;
-    if (graph.translate_asn(4) != 4 ||
-        graph.translate_asn(5) != 5 ||
-        graph.translate_asn(6) != 6)
-        return false;
-    return true;
-}
+//     if (graph.translate_asn(1) != 1 ||
+//         graph.translate_asn(2) != 1 ||
+//         graph.translate_asn(3) != 1)
+//         return false;
+//     if (graph.translate_asn(4) != 4 ||
+//         graph.translate_asn(5) != 5 ||
+//         graph.translate_asn(6) != 6)
+//         return false;
+//     return true;
+// }
 
-/** Test assignment of ranks to each AS in the graph. 
- *  Horizontal lines are peer relationships, vertical lines are customer-provider
- * 
- *    1
- *   / \
- *  2   3--4
- *     / \
- *    5   6
- *
- * @return true if successful, otherwise false.
- */
-bool test_decide_ranks(){
-    ASGraph graph = ASGraph(false, false);
-    graph.add_relationship(2, 1, AS_REL_PROVIDER);
-    graph.add_relationship(1, 2, AS_REL_CUSTOMER);
-    graph.add_relationship(3, 1, AS_REL_PROVIDER);
-    graph.add_relationship(1, 3, AS_REL_CUSTOMER);
-    graph.add_relationship(5, 3, AS_REL_PROVIDER);
-    graph.add_relationship(3, 5, AS_REL_CUSTOMER);
-    graph.add_relationship(6, 3, AS_REL_PROVIDER);
-    graph.add_relationship(3, 6, AS_REL_CUSTOMER);
-    graph.add_relationship(4, 3, AS_REL_PEER);
-    graph.add_relationship(3, 4, AS_REL_PEER);
-    graph.decide_ranks();
-    int num_systems = 6;
-    int acc = 0;
-    for (auto set : *graph.ases_by_rank) {
-        acc += set->size();
-    }
-    if (acc != num_systems) {
-        std::cerr << "Number of ASes in ases_by_rank != total number of ASes." << std::endl;
-        return false;
-    }
-    if (graph.ases->find(1)->second->rank == 2 &&
-        graph.ases->find(2)->second->rank == 0 &&
-        graph.ases->find(3)->second->rank == 1 &&
-        graph.ases->find(4)->second->rank == 0 &&
-        graph.ases->find(5)->second->rank == 0 &&
-        graph.ases->find(6)->second->rank == 0) {
-        return true;
-    }
-    return false;
-}
+// /** Test assignment of ranks to each AS in the graph. 
+//  *  Horizontal lines are peer relationships, vertical lines are customer-provider
+//  * 
+//  *    1
+//  *   / \
+//  *  2   3--4
+//  *     / \
+//  *    5   6
+//  *
+//  * @return true if successful, otherwise false.
+//  */
+// bool test_decide_ranks(){
+//     ASGraph<> graph = ASGraph<>(false, false);
+//     graph.add_relationship(2, 1, AS_REL_PROVIDER);
+//     graph.add_relationship(1, 2, AS_REL_CUSTOMER);
+//     graph.add_relationship(3, 1, AS_REL_PROVIDER);
+//     graph.add_relationship(1, 3, AS_REL_CUSTOMER);
+//     graph.add_relationship(5, 3, AS_REL_PROVIDER);
+//     graph.add_relationship(3, 5, AS_REL_CUSTOMER);
+//     graph.add_relationship(6, 3, AS_REL_PROVIDER);
+//     graph.add_relationship(3, 6, AS_REL_CUSTOMER);
+//     graph.add_relationship(4, 3, AS_REL_PEER);
+//     graph.add_relationship(3, 4, AS_REL_PEER);
+//     graph.decide_ranks();
+//     int num_systems = 6;
+//     int acc = 0;
+//     for (auto set : *graph.ases_by_rank) {
+//         acc += set->size();
+//     }
+//     if (acc != num_systems) {
+//         std::cerr << "Number of ASes in ases_by_rank != total number of ASes." << std::endl;
+//         return false;
+//     }
+//     if (graph.ases->find(1)->second->rank == 2 &&
+//         graph.ases->find(2)->second->rank == 0 &&
+//         graph.ases->find(3)->second->rank == 1 &&
+//         graph.ases->find(4)->second->rank == 0 &&
+//         graph.ases->find(5)->second->rank == 0 &&
+//         graph.ases->find(6)->second->rank == 0) {
+//         return true;
+//     }
+//     return false;
+// }
 
-/** Test removing stub ASes from the graph. 
- * 
- *    1
- *   / \
- *  2   3--4
- *     / \
- *    5   6
- *
- * @return true if successful, otherwise false.
- */
-bool test_remove_stubs(){
-    ASGraph graph = ASGraph(false, false);
-    SQLQuerier *querier = new SQLQuerier("mrt_announcements", "test_results", "test_results", "test_results_d");
-    graph.add_relationship(2, 1, AS_REL_PROVIDER);
-    graph.add_relationship(1, 2, AS_REL_CUSTOMER);
-    graph.add_relationship(3, 1, AS_REL_PROVIDER);
-    graph.add_relationship(1, 3, AS_REL_CUSTOMER);
-    graph.add_relationship(5, 3, AS_REL_PROVIDER);
-    graph.add_relationship(3, 5, AS_REL_CUSTOMER);
-    graph.add_relationship(6, 3, AS_REL_PROVIDER);
-    graph.add_relationship(3, 6, AS_REL_CUSTOMER);
-    graph.add_relationship(4, 3, AS_REL_PEER);
-    graph.add_relationship(3, 4, AS_REL_PEER);
-    graph.remove_stubs(querier);
-    delete querier;
-    // Stub removal
-    if (graph.ases->find(2) != graph.ases->end() ||
-        graph.ases->find(5) != graph.ases->end() ||
-        graph.ases->find(6) != graph.ases->end()) {
-        std::cerr << "Failed stubs removal check." << std::endl;
-        return false;
-    }
-    // Stub translation
-    if (graph.translate_asn(2) != 1 ||
-        graph.translate_asn(5) != 3 ||
-        graph.translate_asn(6) != 3) {
-        std::cerr << "Failed stubs translation check." << std::endl;
-        return false;
-    }
-    return true;
-}
+// /** Test removing stub ASes from the graph. 
+//  * 
+//  *    1
+//  *   / \
+//  *  2   3--4
+//  *     / \
+//  *    5   6
+//  *
+//  * @return true if successful, otherwise false.
+//  */
+// bool test_remove_stubs(){
+//     ASGraph<> graph = ASGraph<>(false, false);
+//     SQLQuerier *querier = new SQLQuerier("mrt_announcements", "test_results", "test_results", "test_results_d");
+//     graph.add_relationship(2, 1, AS_REL_PROVIDER);
+//     graph.add_relationship(1, 2, AS_REL_CUSTOMER);
+//     graph.add_relationship(3, 1, AS_REL_PROVIDER);
+//     graph.add_relationship(1, 3, AS_REL_CUSTOMER);
+//     graph.add_relationship(5, 3, AS_REL_PROVIDER);
+//     graph.add_relationship(3, 5, AS_REL_CUSTOMER);
+//     graph.add_relationship(6, 3, AS_REL_PROVIDER);
+//     graph.add_relationship(3, 6, AS_REL_CUSTOMER);
+//     graph.add_relationship(4, 3, AS_REL_PEER);
+//     graph.add_relationship(3, 4, AS_REL_PEER);
+//     graph.remove_stubs(querier);
+//     delete querier;
+//     // Stub removal
+//     if (graph.ases->find(2) != graph.ases->end() ||
+//         graph.ases->find(5) != graph.ases->end() ||
+//         graph.ases->find(6) != graph.ases->end()) {
+//         std::cerr << "Failed stubs removal check." << std::endl;
+//         return false;
+//     }
+//     // Stub translation
+//     if (graph.translate_asn(2) != 1 ||
+//         graph.translate_asn(5) != 3 ||
+//         graph.translate_asn(6) != 3) {
+//         std::cerr << "Failed stubs translation check." << std::endl;
+//         return false;
+//     }
+//     return true;
+// }
 
-/** Test the Tarjan algorithm for detecting strongly connected components.
- * Horizontal lines are peer relationships, vertical lines are customer-provider
- * 
- *    1
- *   / \
- *  2<- 3--4
- *     / \
- *    5   6
- *
- * @return true if successful, otherwise false.
- */
-bool test_tarjan(){ // includes tarjan_helper()
-    ASGraph graph = ASGraph(false, false);
-    // Cycle 
-    graph.add_relationship(2, 1, AS_REL_PROVIDER);
-    graph.add_relationship(1, 2, AS_REL_CUSTOMER);
-    graph.add_relationship(1, 3, AS_REL_PROVIDER);
-    graph.add_relationship(3, 1, AS_REL_CUSTOMER);
-    graph.add_relationship(3, 2, AS_REL_PROVIDER);
-    graph.add_relationship(2, 3, AS_REL_CUSTOMER);
-    // Customer
-    graph.add_relationship(5, 3, AS_REL_PROVIDER);
-    graph.add_relationship(3, 5, AS_REL_CUSTOMER);
-    graph.add_relationship(6, 3, AS_REL_PROVIDER);
-    graph.add_relationship(3, 6, AS_REL_CUSTOMER);
-    // Peer
-    graph.add_relationship(4, 3, AS_REL_PEER);
-    graph.add_relationship(3, 4, AS_REL_PEER);
-    graph.tarjan();
-    if (graph.components->size() != 4) {
-        return false;
-    }
-    // Verify the cycle was detected
-    for (auto const& c : *graph.components) {
-        if (c->size() > 1 && c->size() != 3)
-            return false;
-    }   
+// /** Test the Tarjan algorithm for detecting strongly connected components.
+//  * Horizontal lines are peer relationships, vertical lines are customer-provider
+//  * 
+//  *    1
+//  *   / \
+//  *  2<- 3--4
+//  *     / \
+//  *    5   6
+//  *
+//  * @return true if successful, otherwise false.
+//  */
+// bool test_tarjan(){ // includes tarjan_helper()
+//     ASGraph<> graph = ASGraph<>(false, false);
+//     // Cycle 
+//     graph.add_relationship(2, 1, AS_REL_PROVIDER);
+//     graph.add_relationship(1, 2, AS_REL_CUSTOMER);
+//     graph.add_relationship(1, 3, AS_REL_PROVIDER);
+//     graph.add_relationship(3, 1, AS_REL_CUSTOMER);
+//     graph.add_relationship(3, 2, AS_REL_PROVIDER);
+//     graph.add_relationship(2, 3, AS_REL_CUSTOMER);
+//     // Customer
+//     graph.add_relationship(5, 3, AS_REL_PROVIDER);
+//     graph.add_relationship(3, 5, AS_REL_CUSTOMER);
+//     graph.add_relationship(6, 3, AS_REL_PROVIDER);
+//     graph.add_relationship(3, 6, AS_REL_CUSTOMER);
+//     // Peer
+//     graph.add_relationship(4, 3, AS_REL_PEER);
+//     graph.add_relationship(3, 4, AS_REL_PEER);
+//     graph.tarjan();
+//     if (graph.components->size() != 4) {
+//         return false;
+//     }
+//     // Verify the cycle was detected
+//     for (auto const& c : *graph.components) {
+//         if (c->size() > 1 && c->size() != 3)
+//             return false;
+//     }   
      
-    // Multi supernode test
-    ASGraph graph2 = ASGraph(false, false);
-    // Cycle 10->11->12->10
-    graph2.add_relationship(11, 10, AS_REL_PROVIDER);
-    graph2.add_relationship(10, 11, AS_REL_CUSTOMER);
-    graph2.add_relationship(12, 11, AS_REL_PROVIDER);
-    graph2.add_relationship(11, 12, AS_REL_CUSTOMER);
-    graph2.add_relationship(10, 12, AS_REL_PROVIDER);
-    graph2.add_relationship(12, 10, AS_REL_CUSTOMER);
-    // Cycle 13->14->15->13
-    graph2.add_relationship(14, 13, AS_REL_PROVIDER);
-    graph2.add_relationship(13, 14, AS_REL_CUSTOMER);
-    graph2.add_relationship(15, 14, AS_REL_PROVIDER);
-    graph2.add_relationship(14, 15, AS_REL_CUSTOMER);
-    graph2.add_relationship(13, 15, AS_REL_PROVIDER);
-    graph2.add_relationship(15, 13, AS_REL_CUSTOMER);
-    // Peer
-    graph2.add_relationship(11, 14, AS_REL_PEER);
-    graph2.add_relationship(14, 11, AS_REL_PEER);
-    graph2.tarjan();
+//     // Multi supernode test
+//     ASGraph<> graph2 = ASGraph<>(false, false);
+//     // Cycle 10->11->12->10
+//     graph2.add_relationship(11, 10, AS_REL_PROVIDER);
+//     graph2.add_relationship(10, 11, AS_REL_CUSTOMER);
+//     graph2.add_relationship(12, 11, AS_REL_PROVIDER);
+//     graph2.add_relationship(11, 12, AS_REL_CUSTOMER);
+//     graph2.add_relationship(10, 12, AS_REL_PROVIDER);
+//     graph2.add_relationship(12, 10, AS_REL_CUSTOMER);
+//     // Cycle 13->14->15->13
+//     graph2.add_relationship(14, 13, AS_REL_PROVIDER);
+//     graph2.add_relationship(13, 14, AS_REL_CUSTOMER);
+//     graph2.add_relationship(15, 14, AS_REL_PROVIDER);
+//     graph2.add_relationship(14, 15, AS_REL_CUSTOMER);
+//     graph2.add_relationship(13, 15, AS_REL_PROVIDER);
+//     graph2.add_relationship(15, 13, AS_REL_CUSTOMER);
+//     // Peer
+//     graph2.add_relationship(11, 14, AS_REL_PEER);
+//     graph2.add_relationship(14, 11, AS_REL_PEER);
+//     graph2.tarjan();
     
-    if (graph2.components->size() != 2) {
-        return false;
-    }
-    // Verify the cycle was detected
-    for (auto const& c : *graph2.components) {
-        if (c->size() > 1 && c->size() != 3)
-            return false;
-    }
+//     if (graph2.components->size() != 2) {
+//         return false;
+//     }
+//     // Verify the cycle was detected
+//     for (auto const& c : *graph2.components) {
+//         if (c->size() > 1 && c->size() != 3)
+//             return false;
+//     }
    
-    srand(time(NULL));
-    for (int i = 0; i < 100; i++) {
-        ASGraph *graph3;
-        graph3 = ran_graph(100, 100);
-        graph3->tarjan();
+//     srand(time(NULL));
+//     for (int i = 0; i < 100; i++) {
+//         ASGraph<> *graph3;
+//         graph3 = ran_graph(100, 100);
+//         graph3->tarjan();
 
-        bool tarjan_cyclic = false;
-        bool cyclic = is_cyclic(graph3);
-        if (cyclic) {
-            for (auto &component : *graph3->components) {
-               if (component->size() > 1) {
-                  tarjan_cyclic = true;
-               }
-            }
-            if (tarjan_cyclic != cyclic) {
-                return false;
-            }
-        } 
-        //graph3->combine_components();
-        // if this terminates, there are no cycles in the graph
-        //graph3->decide_ranks();
-        delete graph3;
-    }
-    return true;
-}
+//         bool tarjan_cyclic = false;
+//         bool cyclic = is_cyclic(graph3);
+//         if (cyclic) {
+//             for (auto &component : *graph3->components) {
+//                if (component->size() > 1) {
+//                   tarjan_cyclic = true;
+//                }
+//             }
+//             if (tarjan_cyclic != cyclic) {
+//                 return false;
+//             }
+//         } 
+//         //graph3->combine_components();
+//         // if this terminates, there are no cycles in the graph
+//         //graph3->decide_ranks();
+//         delete graph3;
+//     }
+//     return true;
+// }
 
-/** Test the combining of strongly connected components into supernodes.
- * 
- *        7
- *        |
- *        1
- *     /  |  \
- * 8--2 ->3-- 4
- *       / \
- *      5   6
- *
- *
- * @return true if successful, otherwise false.
- */
-bool test_combine_components(){
-    ASGraph graph = ASGraph(false, false);
-    // Cycle 1->2->3->1
-    graph.add_relationship(2, 1, AS_REL_PROVIDER);
-    graph.add_relationship(1, 2, AS_REL_CUSTOMER);
-    graph.add_relationship(3, 2, AS_REL_PROVIDER);
-    graph.add_relationship(2, 3, AS_REL_CUSTOMER);
-    graph.add_relationship(1, 3, AS_REL_PROVIDER);
-    graph.add_relationship(3, 1, AS_REL_CUSTOMER);
-    // Provider
-    graph.add_relationship(1, 7, AS_REL_PROVIDER);
-    graph.add_relationship(7, 1, AS_REL_CUSTOMER);
-    graph.add_relationship(4, 1, AS_REL_PROVIDER);
-    graph.add_relationship(1, 4, AS_REL_CUSTOMER);
-    // Customer
-    graph.add_relationship(5, 3, AS_REL_PROVIDER);
-    graph.add_relationship(3, 5, AS_REL_CUSTOMER);
-    graph.add_relationship(6, 3, AS_REL_PROVIDER);
-    graph.add_relationship(3, 6, AS_REL_CUSTOMER);
-    // Peer
-    graph.add_relationship(4, 3, AS_REL_PEER);
-    graph.add_relationship(3, 4, AS_REL_PEER);
-    graph.add_relationship(8, 2, AS_REL_PEER);
-    graph.add_relationship(2, 8, AS_REL_PEER);
+// /** Test the combining of strongly connected components into supernodes.
+//  * 
+//  *        7
+//  *        |
+//  *        1
+//  *     /  |  \
+//  * 8--2 ->3-- 4
+//  *       / \
+//  *      5   6
+//  *
+//  *
+//  * @return true if successful, otherwise false.
+//  */
+// bool test_combine_components(){
+//     ASGraph<> graph = ASGraph<>(false, false);
+//     // Cycle 1->2->3->1
+//     graph.add_relationship(2, 1, AS_REL_PROVIDER);
+//     graph.add_relationship(1, 2, AS_REL_CUSTOMER);
+//     graph.add_relationship(3, 2, AS_REL_PROVIDER);
+//     graph.add_relationship(2, 3, AS_REL_CUSTOMER);
+//     graph.add_relationship(1, 3, AS_REL_PROVIDER);
+//     graph.add_relationship(3, 1, AS_REL_CUSTOMER);
+//     // Provider
+//     graph.add_relationship(1, 7, AS_REL_PROVIDER);
+//     graph.add_relationship(7, 1, AS_REL_CUSTOMER);
+//     graph.add_relationship(4, 1, AS_REL_PROVIDER);
+//     graph.add_relationship(1, 4, AS_REL_CUSTOMER);
+//     // Customer
+//     graph.add_relationship(5, 3, AS_REL_PROVIDER);
+//     graph.add_relationship(3, 5, AS_REL_CUSTOMER);
+//     graph.add_relationship(6, 3, AS_REL_PROVIDER);
+//     graph.add_relationship(3, 6, AS_REL_CUSTOMER);
+//     // Peer
+//     graph.add_relationship(4, 3, AS_REL_PEER);
+//     graph.add_relationship(3, 4, AS_REL_PEER);
+//     graph.add_relationship(8, 2, AS_REL_PEER);
+//     graph.add_relationship(2, 8, AS_REL_PEER);
 
-    graph.tarjan();
-    graph.combine_components();
-    // Check for the supernode
-    if (graph.component_translation->size() != 3) {
-        std::cerr << "Incorrect translation size." << std::endl;
-        return false;
-    }
-    // Verify lowest ASN is identifier
-    for (auto c : *graph.component_translation) {
-        if (c.second != 1) {
-            std::cerr << "Incorrect translation ID for supernode." << std::endl;
-            return false;
-        }
-    }
+//     graph.tarjan();
+//     graph.combine_components();
+//     // Check for the supernode
+//     if (graph.component_translation->size() != 3) {
+//         std::cerr << "Incorrect translation size." << std::endl;
+//         return false;
+//     }
+//     // Verify lowest ASN is identifier
+//     for (auto c : *graph.component_translation) {
+//         if (c.second != 1) {
+//             std::cerr << "Incorrect translation ID for supernode." << std::endl;
+//             return false;
+//         }
+//     }
 
-    // Find supernode AS
-    auto SCC = graph.ases->find(1);
-    AS *supernode = SCC->second;
-    // Check supernode providers
-    if (supernode->providers->find(7) == supernode->providers->end()) {
-        std::cerr << "Incorrect supernode provider set." << std::endl;
-        return false;
-    }
-    // Check supernode customers
-    if (supernode->customers->find(4) == supernode->customers->end() ||
-        supernode->customers->find(5) == supernode->customers->end() ||
-        supernode->customers->find(6) == supernode->customers->end()) {
-        std::cerr << "Incorrect supernode customer set." << std::endl;
-        return false;
-    }
-    // Check supernode peers
-    if (supernode->peers->find(8) == supernode->peers->end()) {
-        std::cerr << "Incorrect supernode peer set." << std::endl;
-        return false;
-    }
-    // Check supernode peers
-    if (supernode->peers->find(4) != supernode->peers->end()) {
-        std::cerr << "Incorrect supernode peer-customer override." << std::endl;
-        return false;
-    }
+//     // Find supernode AS
+//     auto SCC = graph.ases->find(1);
+//     AS<> *supernode = SCC->second;
+//     // Check supernode providers
+//     if (supernode->providers->find(7) == supernode->providers->end()) {
+//         std::cerr << "Incorrect supernode provider set." << std::endl;
+//         return false;
+//     }
+//     // Check supernode customers
+//     if (supernode->customers->find(4) == supernode->customers->end() ||
+//         supernode->customers->find(5) == supernode->customers->end() ||
+//         supernode->customers->find(6) == supernode->customers->end()) {
+//         std::cerr << "Incorrect supernode customer set." << std::endl;
+//         return false;
+//     }
+//     // Check supernode peers
+//     if (supernode->peers->find(8) == supernode->peers->end()) {
+//         std::cerr << "Incorrect supernode peer set." << std::endl;
+//         return false;
+//     }
+//     // Check supernode peers
+//     if (supernode->peers->find(4) != supernode->peers->end()) {
+//         std::cerr << "Incorrect supernode peer-customer override." << std::endl;
+//         return false;
+//     }
 
 
-    // Multi supernode test
-    ASGraph graph2 = ASGraph(false, false);
-    // Cycle 10->11->12->10
-    graph2.add_relationship(11, 10, AS_REL_PROVIDER);
-    graph2.add_relationship(10, 11, AS_REL_CUSTOMER);
-    graph2.add_relationship(12, 11, AS_REL_PROVIDER);
-    graph2.add_relationship(11, 12, AS_REL_CUSTOMER);
-    graph2.add_relationship(10, 12, AS_REL_PROVIDER);
-    graph2.add_relationship(12, 10, AS_REL_CUSTOMER);
-    // Cycle 13->14->15->13
-    graph2.add_relationship(14, 13, AS_REL_PROVIDER);
-    graph2.add_relationship(13, 14, AS_REL_CUSTOMER);
-    graph2.add_relationship(15, 14, AS_REL_PROVIDER);
-    graph2.add_relationship(14, 15, AS_REL_CUSTOMER);
-    graph2.add_relationship(13, 15, AS_REL_PROVIDER);
-    graph2.add_relationship(15, 13, AS_REL_CUSTOMER);
-    // Peer
-    graph2.add_relationship(11, 14, AS_REL_PEER);
-    graph2.add_relationship(14, 11, AS_REL_PEER);
+//     // Multi supernode test
+//     ASGraph<> graph2 = ASGraph<>(false, false);
+//     // Cycle 10->11->12->10
+//     graph2.add_relationship(11, 10, AS_REL_PROVIDER);
+//     graph2.add_relationship(10, 11, AS_REL_CUSTOMER);
+//     graph2.add_relationship(12, 11, AS_REL_PROVIDER);
+//     graph2.add_relationship(11, 12, AS_REL_CUSTOMER);
+//     graph2.add_relationship(10, 12, AS_REL_PROVIDER);
+//     graph2.add_relationship(12, 10, AS_REL_CUSTOMER);
+//     // Cycle 13->14->15->13
+//     graph2.add_relationship(14, 13, AS_REL_PROVIDER);
+//     graph2.add_relationship(13, 14, AS_REL_CUSTOMER);
+//     graph2.add_relationship(15, 14, AS_REL_PROVIDER);
+//     graph2.add_relationship(14, 15, AS_REL_CUSTOMER);
+//     graph2.add_relationship(13, 15, AS_REL_PROVIDER);
+//     graph2.add_relationship(15, 13, AS_REL_CUSTOMER);
+//     // Peer
+//     graph2.add_relationship(11, 14, AS_REL_PEER);
+//     graph2.add_relationship(14, 11, AS_REL_PEER);
     
-    graph2.add_relationship(12, 14, AS_REL_PEER);
-    graph2.add_relationship(14, 12, AS_REL_PEER);
+//     graph2.add_relationship(12, 14, AS_REL_PEER);
+//     graph2.add_relationship(14, 12, AS_REL_PEER);
     
-    graph2.add_relationship(12, 15, AS_REL_PEER);
-    graph2.add_relationship(15, 12, AS_REL_PEER);
+//     graph2.add_relationship(12, 15, AS_REL_PEER);
+//     graph2.add_relationship(15, 12, AS_REL_PEER);
 
-    // Provider
-    //graph2.add_relationship(11, 15, AS_REL_PROVIDER);
-    //graph2.add_relationship(15, 11, AS_REL_CUSTOMER);
+//     // Provider
+//     //graph2.add_relationship(11, 15, AS_REL_PROVIDER);
+//     //graph2.add_relationship(15, 11, AS_REL_CUSTOMER);
 
-    graph2.tarjan();
-    graph2.combine_components();
+//     graph2.tarjan();
+//     graph2.combine_components();
 
-    if (graph2.component_translation->size() != 6) {
-        std::cerr << "Incorrect translation size: " << std::endl;
-        return false;
-    }
+//     if (graph2.component_translation->size() != 6) {
+//         std::cerr << "Incorrect translation size: " << std::endl;
+//         return false;
+//     }
 
-    // Find supernode AS
-    //std::cout << graph2 << std::endl;
-    auto SCC1 = graph2.ases->find(10);
-    auto SCC2 = graph2.ases->find(13);
-    AS *supernode1 = SCC1->second;
-    AS *supernode2 = SCC2->second;
-    // Check supernode providers
-    if (supernode1->providers->find(13) != supernode1->providers->end()) {
-        std::cerr << "Incorrect supernode provider set." << std::endl;
-        return false;
-    }
-    // Check supernode peers
-    if (supernode1->peers->find(13) == supernode1->peers->end() ||
-        supernode2->peers->find(10) == supernode2->peers->end()) {
-        std::cerr << "Incorrect supernode peer set." << std::endl;
-        return false;
-    }
-    return true;
-}
+//     // Find supernode AS
+//     //std::cout << graph2 << std::endl;
+//     auto SCC1 = graph2.ases->find(10);
+//     auto SCC2 = graph2.ases->find(13);
+//     AS<> *supernode1 = SCC1->second;
+//     AS<> *supernode2 = SCC2->second;
+//     // Check supernode providers
+//     if (supernode1->providers->find(13) != supernode1->providers->end()) {
+//         std::cerr << "Incorrect supernode provider set." << std::endl;
+//         return false;
+//     }
+//     // Check supernode peers
+//     if (supernode1->peers->find(13) == supernode1->peers->end() ||
+//         supernode2->peers->find(10) == supernode2->peers->end()) {
+//         std::cerr << "Incorrect supernode peer set." << std::endl;
+//         return false;
+//     }
+//     return true;
+// }

--- a/src/Tests/ASTest.cpp
+++ b/src/Tests/ASTest.cpp
@@ -34,8 +34,8 @@
  */
 bool test_get_random(){
     // Check randomness
-    AS *as_a = new AS(832);
-    AS *as_b = new AS(832);
+    AS<> *as_a = new AS<>(832);
+    AS<> *as_b = new AS<>(832);
     bool ran_a_1 = as_a->get_random();
     bool ran_a_2 = as_a->get_random();
     bool ran_a_3 = as_a->get_random();
@@ -59,7 +59,7 @@ bool test_get_random(){
  * @return True if successful, otherwise false
  */
 bool test_add_neighbor(){
-    AS as = AS();
+    AS<> as = AS<>();
     as.add_neighbor(1, AS_REL_PROVIDER);
     as.add_neighbor(2, AS_REL_PEER);
     as.add_neighbor(3, AS_REL_CUSTOMER);
@@ -77,7 +77,7 @@ bool test_add_neighbor(){
  * @return True if successful, otherwise false
  */
 bool test_remove_neighbor(){
-    AS as = AS();
+    AS<> as = AS<>();
     as.add_neighbor(1, AS_REL_PROVIDER);
     as.add_neighbor(2, AS_REL_PEER);
     as.add_neighbor(3, AS_REL_CUSTOMER);
@@ -98,8 +98,8 @@ bool test_remove_neighbor(){
  * @return true if successful.
  */
 bool test_receive_announcements(){
-    Announcement ann = Announcement(13796, 0x89630000, 0xFFFF0000, 22742);
-    std::vector<Announcement> vect = std::vector<Announcement>();
+    Announcement<> ann = Announcement<>(13796, 0x89630000, 0xFFFF0000, 22742);
+    std::vector<Announcement<>> vect = std::vector<Announcement<>>();
     vect.push_back(ann);
     // this function should make a copy of the announcement
     // if it does not, it is incorrect
@@ -108,11 +108,11 @@ bool test_receive_announcements(){
     ann.prefix.netmask = 0xFFFFFF00;
     Prefix<> new_prefix = ann.prefix;
     vect.push_back(ann);
-    AS as = AS();
+    AS<> as = AS<>();
     as.receive_announcements(vect);
     if (as.incoming_announcements->size() != 2) { return false; }
     // order really doesn't matter here
-    for (Announcement a : *as.incoming_announcements) {
+    for (Announcement<> a : *as.incoming_announcements) {
         if (a.prefix != old_prefix && a.prefix != new_prefix) {
             return false;
         }
@@ -125,10 +125,10 @@ bool test_receive_announcements(){
  * @return true if successful.
  */
 bool test_process_announcement(){
-    Announcement ann = Announcement(13796, 0x89630000, 0xFFFF0000, 22742);
+    Announcement<> ann = Announcement<>(13796, 0x89630000, 0xFFFF0000, 22742);
     // this function should make a copy of the announcement
     // if it does not, it is incorrect
-    AS as = AS(0, true);
+    AS<> as = AS<>(0, true);
     as.process_announcement(ann, true);
     Prefix<> old_prefix = ann.prefix;
     ann.prefix.addr = 0x321C9F00;
@@ -142,8 +142,8 @@ bool test_process_announcement(){
 
     // Check priority
     Prefix<> p = Prefix<>("1.1.1.0", "255.255.255.0");
-    Announcement a1 = Announcement(111, p.addr, p.netmask, 199, 222, false);
-    Announcement a2 = Announcement(111, p.addr, p.netmask, 298, 223, false);
+    Announcement<> a1 = Announcement<>(111, p.addr, p.netmask, 199, 222, false);
+    Announcement<> a2 = Announcement<>(111, p.addr, p.netmask, 298, 223, false);
     as.process_announcement(a1, true);
     as.process_announcement(a2, true);
     if (as.all_anns->find(p)->second.received_from_asn != 223 ||
@@ -153,7 +153,7 @@ bool test_process_announcement(){
     }    
 
     // Check new best announcement
-    Announcement a3 = Announcement(111, p.addr, p.netmask, 299, 224, false);
+    Announcement<> a3 = Announcement<>(111, p.addr, p.netmask, 299, 224, false);
     as.process_announcement(a3, true);
     if (as.all_anns->find(p)->second.received_from_asn != 224 ||
         as.depref_anns->find(p)->second.received_from_asn != 223) {
@@ -174,13 +174,13 @@ bool test_process_announcement(){
  * Item three requires the from_monitor attribute to work. 
  */
 bool test_process_announcements(){
-    Announcement ann1 = Announcement(13796, 0x89630000, 0xFFFF0000, 22742);
+    Announcement<> ann1 = Announcement<>(13796, 0x89630000, 0xFFFF0000, 22742);
     Prefix<> ann1_prefix = ann1.prefix;
-    Announcement ann2 = Announcement(13796, 0x321C9F00, 0xFFFFFF00, 22742);
+    Announcement<> ann2 = Announcement<>(13796, 0x321C9F00, 0xFFFFFF00, 22742);
     Prefix<> ann2_prefix = ann2.prefix;
-    AS as = AS();
+    AS<> as = AS<>();
     // build a vector of announcements
-    std::vector<Announcement> vect = std::vector<Announcement>();
+    std::vector<Announcement<>> vect = std::vector<Announcement<>>();
     ann1.priority = 100;
     ann2.priority = 200;
     ann2.from_monitor = true;
@@ -246,8 +246,8 @@ bool test_process_announcements(){
  * @return true if successful.
  */
 bool test_clear_announcements(){
-    Announcement ann = Announcement(13796, 0x89630000, 0xFFFF0000, 22742);
-    AS as = AS();
+    Announcement<> ann = Announcement<>(13796, 0x89630000, 0xFFFF0000, 22742);
+    AS<> as = AS<>();
     // if receive_announcement is broken, this test will also be broken
     as.process_announcement(ann, true);
     if (as.all_anns->size() != 1) {
@@ -265,9 +265,9 @@ bool test_clear_announcements(){
  * @return true if successful.
  */
 bool test_already_received(){
-    Announcement ann1 = Announcement(13796, 0x89630000, 0xFFFF0000, 22742);
-    Announcement ann2 = Announcement(13796, 0x321C9F00, 0xFFFFFF00, 22742);
-    AS as = AS();
+    Announcement<> ann1 = Announcement<>(13796, 0x89630000, 0xFFFF0000, 22742);
+    Announcement<> ann2 = Announcement<>(13796, 0x321C9F00, 0xFFFFFF00, 22742);
+    AS<> as = AS<>();
     // if receive_announcement is broken, this test will also be broken
     as.process_announcement(ann1, true);
     if (as.already_received(ann1) && !as.already_received(ann2)) {

--- a/src/Tests/AnnouncementTest.cpp
+++ b/src/Tests/AnnouncementTest.cpp
@@ -32,7 +32,7 @@
  * @ return True for success
  */
 bool test_announcement(){
-    Announcement ann = Announcement(111, 0x01010101, 0xffffff00, 262, 222, false);
+    Announcement<> ann = Announcement<>(111, 0x01010101, 0xffffff00, 262, 222, false);
     if (ann.origin != 111 || ann.prefix.addr != 0x01010101 || ann.prefix.netmask != 0xffffff00 || ann.received_from_asn != 222 || ann.priority != 262 || ann.from_monitor != false)
         return false;
     return true;

--- a/src/Tests/ExtrapolatorTest.cpp
+++ b/src/Tests/ExtrapolatorTest.cpp
@@ -34,7 +34,7 @@
 /** It is worth having this test since the constructor is changed so often.
  */
 bool test_Extrapolator_constructor() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     if (e.graph == NULL) { return false; }
     return true;
 }
@@ -42,7 +42,7 @@ bool test_Extrapolator_constructor() {
 /** Test the loop detection in input MRT AS paths.
  */
 bool test_find_loop() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     std::vector<uint32_t> *as_path = new std::vector<uint32_t>();
     as_path->push_back(1);
     as_path->push_back(2);
@@ -82,7 +82,7 @@ bool test_find_loop() {
  *  The test path vect is [3, 2, 5]. 
  */
 bool test_give_ann_to_as_path() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -165,8 +165,9 @@ bool test_give_ann_to_as_path() {
  *  When AS 5 is the origin, an announcement should only be seeded at 5
  */
 bool test_give_ann_to_as_path_origin_only() {
-    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, true, NULL);
+    Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, true, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -225,8 +226,9 @@ bool test_give_ann_to_as_path_origin_only() {
  *  Starting propagation at 5, only 4 and 7 should not see the announcement.
  */
 bool test_propagate_up_no_multihomed() {
-    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL);
+    Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -285,7 +287,7 @@ bool test_propagate_up_no_multihomed() {
  *  Starting propagation at 5, everyone but 4 and 7 should see the announcement.
  */
 bool test_propagate_up() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -344,9 +346,9 @@ bool test_propagate_up() {
  *  Starting propagation at 3, only 3 should see the announcement.
  */
 bool test_propagate_up_multihomed_standard() {
-    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+    Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(3, 2, AS_REL_PROVIDER);
@@ -397,9 +399,9 @@ bool test_propagate_up_multihomed_standard() {
  *  Starting propagation at 3, 3 and 5 should see the announcement.
  */
 bool test_propagate_up_multihomed_peer_mode() {
-    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+    Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE,
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3, DEFAULT_ORIGIN_ONLY, NULL);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(3, 2, AS_REL_PROVIDER);
@@ -451,8 +453,9 @@ bool test_propagate_up_multihomed_peer_mode() {
  *  Starting propagation at 2, 4 and 5 should see the announcement.
  */
 bool test_propagate_down_no_multihomed() {
-    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL);
+    Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -505,8 +508,9 @@ bool test_propagate_down_no_multihomed() {
  *  Starting propagation at 1, everyone but 3 and 6 should see the announcement.
  */
 bool test_propagate_down_no_multihomed2() {
-    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL);
+    Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -562,7 +566,7 @@ bool test_propagate_down_no_multihomed2() {
  *  Starting propagation at 2, 4 and 5 should see the announcement.
  */
 bool test_propagate_down() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -615,7 +619,7 @@ bool test_propagate_down() {
  *  Starting propagation at 1, everyone but 3 and 6 should see the announcement.
  */
 bool test_propagate_down2() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -669,9 +673,9 @@ bool test_propagate_down2() {
  *  Starting propagation at 1, everyone but 5 should see the announcement.
  */
 bool test_propagate_down_multihomed_standard() {
-    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+    Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(3, 2, AS_REL_PROVIDER);
@@ -725,7 +729,7 @@ bool test_propagate_down_multihomed_standard() {
  *  Sending announcements from 4, everyone but 1 should see the announcement.
  */
 bool test_send_all_announcements() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
@@ -799,7 +803,7 @@ bool test_send_all_announcements() {
  *  Sending announcements from 4 with existing announcements at 2 and 3 (same prefix as 4 and origin asn = 4), no one should see the announcement.
  */
 bool test_send_all_announcements2() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
@@ -880,7 +884,7 @@ bool test_send_all_announcements2() {
  *  Sending announcements from 4 with existing announcements at 2 (same prefix as 4 and origin asn = 4), no one should see the announcement.
  */
 bool test_send_all_announcements3() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(4, 2, AS_REL_PROVIDER);
@@ -955,8 +959,9 @@ bool test_send_all_announcements3() {
  *  Starting propagation at 2, only 6 and 7 should not see the announcement.
  */
 bool test_send_all_announcements_no_multihomed() {
-    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL);
+    Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1048,8 +1053,9 @@ bool test_send_all_announcements_no_multihomed() {
  *  Starting propagation at 2, only 6 and 7 should not see the announcement.
  */
 bool test_send_all_announcements_multihomed_standard1() {
-    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL);
+    Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1142,9 +1148,9 @@ bool test_send_all_announcements_multihomed_standard1() {
  *  Starting propagation at 5, only 5 should see the announcement.
  */
 bool test_send_all_announcements_multihomed_standard2() {
-    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+    Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1227,8 +1233,9 @@ bool test_send_all_announcements_multihomed_standard2() {
  *  Starting propagation at 5, only 6 and 7 should not see the announcement.
  */
 bool test_send_all_announcements_multihomed_peer_mode1() {
-    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
-                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3, DEFAULT_ORIGIN_ONLY, NULL);
+    Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+                                            ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1320,9 +1327,9 @@ bool test_send_all_announcements_multihomed_peer_mode1() {
  *  Starting propagation at 5, only 5 and 6 should see the announcement.
  */
 bool test_send_all_announcements_multihomed_peer_mode2() {
-    Extrapolator e = Extrapolator(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
+    Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3, DEFAULT_ORIGIN_ONLY, NULL);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1412,7 +1419,7 @@ bool test_send_all_announcements_multihomed_peer_mode2() {
  *  This test is currently requires manual verification that the results in the database are correct.
  */
 bool test_save_results_parallel() {
-    Extrapolator e = Extrapolator(false, true, false, false, "ignored", "test_extrapolation_results", "unused", "unused", "unused", "bgp", 10000, -1, 0, DEFAULT_ORIGIN_ONLY, NULL);
+    Extrapolator<> e = Extrapolator<>(false, true, false, false, "ignored", "test_extrapolation_results", "unused", "unused", "unused", "bgp", 10000, -1, 0, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1458,7 +1465,7 @@ bool test_save_results_parallel() {
  *  This test is currently requires manual verification that the results in the database are correct.
  */
 bool test_save_results_at_asn() {
-    Extrapolator e = Extrapolator(false, false, false, true, "ignored", "unused", "unused", "unused", "test_extrapolation_single_results", "bgp", 10000, -1, 0, DEFAULT_ORIGIN_ONLY, NULL);
+    Extrapolator<> e = Extrapolator<>(false, false, false, true, "ignored", "unused", "unused", "unused", "test_extrapolation_single_results", "bgp", 10000, -1, 0, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1501,7 +1508,7 @@ bool test_save_results_at_asn() {
  *  Test prepending on path vector [3, 3, 2, 5]. This shouldn't change the priority since prepending is in the back of the path. 
  */
 bool test_prepending_priority_back() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1544,7 +1551,7 @@ bool test_prepending_priority_back() {
  *  Test prepending on path vector [3, 2, 2, 5]. This should reduce the priority at 3. 
  */
 bool test_prepending_priority_middle() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1587,7 +1594,7 @@ bool test_prepending_priority_middle() {
  *  Test prepending on path vector [3, 2, 5, 5]. This should reduce the priority at 3 and 5. 
  */
 bool test_prepending_priority_beginning() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1630,7 +1637,7 @@ bool test_prepending_priority_beginning() {
  *  Test prepending on path vector [3, 3, 2, 5] with an existing announcement at those ASes. This shouldn't change the priority since prepending is in the back of the path.  
  */
 bool test_prepending_priority_back_existing_ann() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1679,7 +1686,7 @@ bool test_prepending_priority_back_existing_ann() {
  *  Test prepending on path vector [3, 2, 2, 5] with an existing announcement at those ASes. This shouldn't change the priority since the existing announcement has higher priority.  
  */
 bool test_prepending_priority_middle_existing_ann() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1728,7 +1735,7 @@ bool test_prepending_priority_middle_existing_ann() {
  *  Test prepending on path vector [3, 2, 5, 5] with an existing announcement at those ASes. This shouldn't change the priority since the existing announcement has higher priority.  
  */
 bool test_prepending_priority_beginning_existing_ann() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1777,7 +1784,7 @@ bool test_prepending_priority_beginning_existing_ann() {
  *  Test prepending on path vector [3, 2, 5, 5] with an existing announcement at those ASes. This should change the priority since the existing announcement has lower priority.  
  */
 bool test_prepending_priority_beginning_existing_ann2() {
-    Extrapolator e = Extrapolator();
+    Extrapolator<> e = Extrapolator<>();
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);

--- a/src/Tests/ExtrapolatorTest.cpp
+++ b/src/Tests/ExtrapolatorTest.cpp
@@ -167,7 +167,7 @@ bool test_give_ann_to_as_path() {
 bool test_give_ann_to_as_path_origin_only() {
     Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, true, NULL, DEFAULT_IPV6_MODE);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, true, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -228,7 +228,7 @@ bool test_give_ann_to_as_path_origin_only() {
 bool test_propagate_up_no_multihomed() {
     Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -245,7 +245,7 @@ bool test_propagate_up_no_multihomed() {
     e.graph->decide_ranks();
     Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
     
-    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    Announcement<> ann = Announcement<>(13796, p.addr, p.netmask, 22742);
     ann.from_monitor = true;
     ann.priority = 290;
     e.graph->ases->find(5)->second->process_announcement(ann, true);
@@ -304,7 +304,7 @@ bool test_propagate_up() {
     e.graph->decide_ranks();
     
     Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
-    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    Announcement<> ann = Announcement<>(13796, p.addr, p.netmask, 22742);
     ann.from_monitor = true;
     ann.priority = 290;
     e.graph->ases->find(5)->second->process_announcement(ann, true);
@@ -348,7 +348,7 @@ bool test_propagate_up() {
 bool test_propagate_up_multihomed_standard() {
     Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(3, 2, AS_REL_PROVIDER);
@@ -363,7 +363,7 @@ bool test_propagate_up_multihomed_standard() {
     e.graph->decide_ranks();
     
     Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
-    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    Announcement<> ann = Announcement<>(13796, p.addr, p.netmask, 22742);
     ann.from_monitor = true;
     ann.priority = 290;
     e.graph->ases->find(3)->second->process_announcement(ann, true);
@@ -401,7 +401,7 @@ bool test_propagate_up_multihomed_standard() {
 bool test_propagate_up_multihomed_peer_mode() {
     Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE,
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3, DEFAULT_ORIGIN_ONLY, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(3, 2, AS_REL_PROVIDER);
@@ -416,7 +416,7 @@ bool test_propagate_up_multihomed_peer_mode() {
     e.graph->decide_ranks();
     
     Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
-    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    Announcement<> ann = Announcement<>(13796, p.addr, p.netmask, 22742);
     ann.from_monitor = true;
     ann.priority = 290;
     e.graph->ases->find(3)->second->process_announcement(ann, true);
@@ -455,7 +455,7 @@ bool test_propagate_up_multihomed_peer_mode() {
 bool test_propagate_down_no_multihomed() {
     Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -470,7 +470,7 @@ bool test_propagate_down_no_multihomed() {
     e.graph->decide_ranks();
     
     Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
-    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    Announcement<> ann = Announcement<>(13796, p.addr, p.netmask, 22742);
     ann.from_monitor = true;
     ann.priority = 290;
     e.graph->ases->find(2)->second->process_announcement(ann, true);
@@ -510,7 +510,7 @@ bool test_propagate_down_no_multihomed() {
 bool test_propagate_down_no_multihomed2() {
     Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -525,7 +525,7 @@ bool test_propagate_down_no_multihomed2() {
     e.graph->decide_ranks();
     
     Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
-    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    Announcement<> ann = Announcement<>(13796, p.addr, p.netmask, 22742);
     ann.from_monitor = true;
     ann.priority = 290;
     e.graph->ases->find(1)->second->process_announcement(ann, true);
@@ -581,7 +581,7 @@ bool test_propagate_down() {
     e.graph->decide_ranks();
     
     Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
-    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    Announcement<> ann = Announcement<>(13796, p.addr, p.netmask, 22742);
     ann.from_monitor = true;
     ann.priority = 290;
     e.graph->ases->find(2)->second->process_announcement(ann, true);
@@ -634,7 +634,7 @@ bool test_propagate_down2() {
     e.graph->decide_ranks();
     
     Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
-    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    Announcement<> ann = Announcement<>(13796, p.addr, p.netmask, 22742);
     ann.from_monitor = true;
     ann.priority = 290;
     e.graph->ases->find(1)->second->process_announcement(ann, true);
@@ -675,7 +675,7 @@ bool test_propagate_down2() {
 bool test_propagate_down_multihomed_standard() {
     Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(3, 2, AS_REL_PROVIDER);
@@ -690,7 +690,7 @@ bool test_propagate_down_multihomed_standard() {
     e.graph->decide_ranks();
     
     Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
-    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    Announcement<> ann = Announcement<>(13796, p.addr, p.netmask, 22742);
     ann.from_monitor = true;
     ann.priority = 290;
     e.graph->ases->find(1)->second->process_announcement(ann, true);
@@ -961,7 +961,7 @@ bool test_send_all_announcements3() {
 bool test_send_all_announcements_no_multihomed() {
     Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 0, DEFAULT_ORIGIN_ONLY, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1055,7 +1055,7 @@ bool test_send_all_announcements_no_multihomed() {
 bool test_send_all_announcements_multihomed_standard1() {
     Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1150,7 +1150,7 @@ bool test_send_all_announcements_multihomed_standard1() {
 bool test_send_all_announcements_multihomed_standard2() {
     Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 2, DEFAULT_ORIGIN_ONLY, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1235,7 +1235,7 @@ bool test_send_all_announcements_multihomed_standard2() {
 bool test_send_all_announcements_multihomed_peer_mode1() {
     Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3, DEFAULT_ORIGIN_ONLY, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1329,7 +1329,7 @@ bool test_send_all_announcements_multihomed_peer_mode1() {
 bool test_send_all_announcements_multihomed_peer_mode2() {
     Extrapolator<> e = Extrapolator<>(DEFAULT_RANDOM_TIEBRAKING, DEFAULT_STORE_RESULTS, DEFAULT_STORE_INVERT_RESULTS, DEFAULT_STORE_DEPREF_RESULTS, 
                                             ANNOUNCEMENTS_TABLE, RESULTS_TABLE, INVERSE_RESULTS_TABLE, DEPREF_RESULTS_TABLE, FULL_PATH_RESULTS_TABLE, 
-                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
+                                            DEFAULT_QUERIER_CONFIG_SECTION, DEFAULT_ITERATION_SIZE, -1, 3, DEFAULT_ORIGIN_ONLY, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1419,7 +1419,7 @@ bool test_send_all_announcements_multihomed_peer_mode2() {
  *  This test is currently requires manual verification that the results in the database are correct.
  */
 bool test_save_results_parallel() {
-    Extrapolator<> e = Extrapolator<>(false, true, false, false, "ignored", "test_extrapolation_results", "unused", "unused", "unused", "bgp", 10000, -1, 0, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
+    Extrapolator<> e = Extrapolator<>(false, true, false, false, "ignored", "test_extrapolation_results", "unused", "unused", "unused", "bgp", 10000, -1, 0, DEFAULT_ORIGIN_ONLY, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1434,7 +1434,7 @@ bool test_save_results_parallel() {
     e.graph->decide_ranks();
     
     Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
-    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    Announcement<> ann = Announcement<>(13796, p.addr, p.netmask, 22742);
     ann.from_monitor = true;
     ann.priority = 290;
     e.graph->ases->find(1)->second->process_announcement(ann, true);
@@ -1465,7 +1465,7 @@ bool test_save_results_parallel() {
  *  This test is currently requires manual verification that the results in the database are correct.
  */
 bool test_save_results_at_asn() {
-    Extrapolator<> e = Extrapolator<>(false, false, false, true, "ignored", "unused", "unused", "unused", "test_extrapolation_single_results", "bgp", 10000, -1, 0, DEFAULT_ORIGIN_ONLY, NULL, DEFAULT_IPV6_MODE);
+    Extrapolator<> e = Extrapolator<>(false, false, false, true, "ignored", "unused", "unused", "unused", "test_extrapolation_single_results", "bgp", 10000, -1, 0, DEFAULT_ORIGIN_ONLY, NULL);
     e.graph->add_relationship(2, 1, AS_REL_PROVIDER);
     e.graph->add_relationship(1, 2, AS_REL_CUSTOMER);
     e.graph->add_relationship(5, 2, AS_REL_PROVIDER);
@@ -1480,7 +1480,7 @@ bool test_save_results_at_asn() {
     e.graph->decide_ranks();
     
     Prefix<> p = Prefix<>("137.99.0.0", "255.255.0.0");
-    Announcement ann = Announcement(13796, p.addr, p.netmask, 22742);
+    Announcement<> ann = Announcement<>(13796, p.addr, p.netmask, 22742);
     ann.from_monitor = true;
     ann.priority = 290;
     e.graph->ases->find(1)->second->process_announcement(ann, true);

--- a/src/Tests/PrefixTests.cpp
+++ b/src/Tests/PrefixTests.cpp
@@ -64,6 +64,58 @@ bool test_prefix(){
    return true;
 }
 
+/** Tests IPv6 Prefix struct constructor.
+ *
+ * @return true if successful, otherwise false.
+ */
+bool test_prefix_ipv6(){
+    // Check string constructor correctness with various edge cases
+    Prefix<uint128_t> prefix = Prefix<uint128_t>("1:1:1:1:1:1:1:0", "FFFF:FFFF:FFFF:FFFF::");
+    // Can't directly assign a 128 bit number because it's too large
+    uint128_t correct_address = ((uint128_t) 0x0001000100010001 << 64) | 0x0001000100010000;
+    uint128_t correct_mask = (uint128_t) 0xffffffffffffffff << 64;
+    if (prefix.addr != correct_address || prefix.netmask != correct_mask)
+       return false;
+
+    prefix = Prefix<uint128_t>("::1", "F::F:F");
+    correct_address = (uint128_t) 0x1;
+    correct_mask = ((uint128_t) 0x000f000000000000 << 64) | 0x00000000000f000f;
+    if (prefix.addr != correct_address || prefix.netmask != correct_mask)
+        return false;
+
+    prefix = Prefix<uint128_t>("1111:1111::1:1111", "ffff:f:ffff:f::");
+    correct_address = ((uint128_t) 0x1111111100000000 << 64) | 0x0000000000011111;
+    correct_mask = (uint128_t) 0xffff000fffff000f << 64;
+    if (prefix.addr != correct_address || prefix.netmask != correct_mask)
+        return false;
+
+    // Check out of range address
+    prefix = Prefix<uint128_t>("FFFFF::", "::");
+    if (prefix.addr != 0x0 || prefix.netmask != 0x0)
+        return false;
+
+    // Check malformed address
+    prefix = Prefix<uint128_t>("1:1:1:1:1:1:1:1:1", "::");
+    if (prefix.addr != 0x0 || prefix.netmask != 0x0)
+        return false;
+
+    // Check malformed address
+    prefix = Prefix<uint128_t>("1:1:1: :1:1:1:1", "::");
+    if (prefix.addr != 0x0 || prefix.netmask != 0x0)
+        return false;
+    
+    // Check malformed address
+    prefix = Prefix<uint128_t>("1:1:1:1:1:1:1: ", "::");
+    if (prefix.addr != 0x0 || prefix.netmask != 0x0)
+        return false;
+    
+    // Check empty address
+    prefix = Prefix<uint128_t>("", "::");
+    if (prefix.addr != 0x0 || prefix.netmask != 0x0)
+        return false;
+
+   return true;
+}
 
 /** Tests the conversion of an address as a string to a cidr.
  *
@@ -76,6 +128,16 @@ bool test_string_to_cidr(){
     return true;
 }
 
+/** Tests the conversion of an IPv6 address as a string to a cidr.
+ *
+ * @return true if successful, otherwise false.
+ */
+bool test_string_to_cidr_ipv6(){
+    Prefix<uint128_t> prefix = Prefix<uint128_t>("1:1:1:1:1:1:1:0", "FFFF:FFFF:FFFF::");
+    if (prefix.to_cidr() != "1:1:1:1:1:1:1:0/48")
+        return false;
+    return true;
+}
 
 /** Tests the definition of the < operator.
  *
@@ -89,6 +151,23 @@ bool test_prefix_lt_operator(){
     return true;
 }
 
+/** Tests the definition of the < operator for IPv6.
+ *
+ * @return true if successful, otherwise false.
+ */
+bool test_prefix_lt_operator_ipv6(){
+    Prefix<uint128_t> a = Prefix<uint128_t>("1:1:1:1:1:1:1:0", "FFFF:FFFF:FFFF::");
+    Prefix<uint128_t> b = Prefix<uint128_t>("1:1:1:1:1:1:1:0", "FFFF:FFFF:FFFE::");
+    if (a < b)
+        return false;
+
+    a = Prefix<uint128_t>("1:1:1:1:1:1:2:0", "FFFF:FFFF:FFFF::");
+    b = Prefix<uint128_t>("1:1:1:1:1:1:1:0", "FFFF:FFFF:FFFF::");
+    if (a < b)
+        return false;
+
+    return true;
+}
 
 /** Tests the definition of the > operator.
  *
@@ -102,6 +181,23 @@ bool test_prefix_gt_operator(){
     return true;
 }
 
+/** Tests the definition of the > operator for IPv6.
+ *
+ * @return true if successful, otherwise false.
+ */
+bool test_prefix_gt_operator_ipv6(){
+    Prefix<uint128_t> a = Prefix<uint128_t>("1:1:1:1:1:1:1:0", "FFFF:FFFF:FFFF::");
+    Prefix<uint128_t> b = Prefix<uint128_t>("1:1:1:1:1:1:1:0", "FFFF:FFFF:FFFE::");
+    if (b > a)
+        return false;
+
+    a = Prefix<uint128_t>("1:1:1:1:1:1:2:0", "FFFF:FFFF:FFFF::");
+    b = Prefix<uint128_t>("1:1:1:1:1:1:1:0", "FFFF:FFFF:FFFF::");
+    if (b > a)
+        return false;
+
+    return true;
+}
 
 /** Tests the definition of the == operator.
  *
@@ -115,6 +211,21 @@ bool test_prefix_eq_operator(){
     return true;
 }
 
+/** Tests the definition of the == operator for IPv6.
+ *
+ * @return true if successful, otherwise false.
+ */
+bool test_prefix_eq_operator_ipv6(){
+    Prefix<uint128_t> a = Prefix<uint128_t>("1:1:1:1:1:1:1:0", "FFFF:FFFF:FFFF::");
+    Prefix<uint128_t> b = Prefix<uint128_t>("1:1:1:1:1:1:1:0", "FFFF:FFFF:FFFE::");
+    if (a == b)
+        return false;
+
+    a = Prefix<uint128_t>("1:1:1:1:1:1:1:0", "FFFF:FFFF:FFFF::");
+    b = Prefix<uint128_t>("1:1:1:1:1:1:1:0", "FFFF:FFFF:FFFF::");
+    return a == b;
+}
+
 /** Tests the contained_in_or_equal_to function.
  *
  * @return true if successful, otherwise false.
@@ -123,6 +234,27 @@ bool test_prefix_contained_in_or_equal_to_operator(){
     Prefix<> a = Prefix<>("1.1.1.0", "255.255.255.0");
     Prefix<> b = Prefix<>("1.1.2.0", "255.255.254.0");
     Prefix<> c = Prefix<>("1.1.0.0", "255.255.0.0");
+    if (!a.contained_in_or_equal_to(c))
+        return false;
+    if (c.contained_in_or_equal_to(a))
+        return false;
+    if (!a.contained_in_or_equal_to(a))
+        return false;
+    if (b.contained_in_or_equal_to(a))
+        return false;
+    if (a.contained_in_or_equal_to(b))
+        return false;
+    return true;
+}
+
+/** Tests the contained_in_or_equal_to function for IPv6.
+ *
+ * @return true if successful, otherwise false.
+ */
+bool test_prefix_contained_in_or_equal_to_operator_ipv6(){
+    Prefix<uint128_t> a = Prefix<uint128_t>("1:1:1:1:1:1:1:0", "FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:0");
+    Prefix<uint128_t> b = Prefix<uint128_t>("1:1:1:1:1:1:2:0", "FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFE:0");
+    Prefix<uint128_t> c = Prefix<uint128_t>("1:1:1:1:1:1:0:0", "FFFF:FFFF:FFFF:FFFF:FFFF:FFFF::");
     if (!a.contained_in_or_equal_to(c))
         return false;
     if (c.contained_in_or_equal_to(a))

--- a/src/Tests/ROVppTests.cpp
+++ b/src/Tests/ROVppTests.cpp
@@ -737,7 +737,7 @@ bool test_rovpp_decide_ranks(){
  */
 bool test_rovpp_remove_stubs(){
     ROVppASGraph graph = ROVppASGraph();
-    SQLQuerier *querier = new SQLQuerier("mrt_announcements", "test_results", "test_results", "test_results_d");
+    SQLQuerier<> *querier = new SQLQuerier<>("mrt_announcements", "test_results", "test_results", "test_results_d");
     graph.add_relationship(2, 1, AS_REL_PROVIDER);
     graph.add_relationship(1, 2, AS_REL_CUSTOMER);
     graph.add_relationship(3, 1, AS_REL_PROVIDER);
@@ -854,7 +854,7 @@ bool test_rovpp_receive_announcements(){
     as.receive_announcements(vect);
     if (as.ribs_in->size() != 2) { return false; }
     // order really doesn't matter here
-    for (Announcement a : *as.ribs_in) {
+    for (Announcement<> a : *as.ribs_in) {
         if (a.prefix != old_prefix && a.prefix != new_prefix) {
             return false;
         }

--- a/src/Tests/SQLQuerierTest.cpp
+++ b/src/Tests/SQLQuerierTest.cpp
@@ -31,7 +31,7 @@ bool test_parse_config_teardown() {
 bool test_parse_config() {
     bool failed = false;
     try {
-        SQLQuerier *querier = new SQLQuerier("announcement_table", "results_table", "inverse_results_table", "depref_results_table", "full_path_results_table", -1, "test", "bgp-test.conf", false);
+        SQLQuerier<> *querier = new SQLQuerier<>("announcement_table", "results_table", "inverse_results_table", "depref_results_table", "full_path_results_table", -1, "test", "bgp-test.conf", false);
 
         if (querier->host != "test0"){
             std::cerr << "Failed to parse password" << std::endl;

--- a/src/Tests/SQLQuerierTest.cpp
+++ b/src/Tests/SQLQuerierTest.cpp
@@ -65,7 +65,7 @@ bool test_parse_config() {
 
 // Test for copy_to_db_string function
 bool test_copy_to_db_string() {
-    SQLQuerier *querier = new SQLQuerier("announcement_table", "results_table", "inverse_results_table", "depref_results_table", "full_path_results_table", -1, "test", "bgp-test.conf", false);
+    SQLQuerier<> *querier = new SQLQuerier<>("announcement_table", "results_table", "inverse_results_table", "depref_results_table", "full_path_results_table", -1, "test", "bgp-test.conf", false);
 
     if (querier->copy_to_db_query_string("test", "stubs", "(stub_asn,parent_asn)") != 
                                     "COPY stubs(stub_asn,parent_asn) FROM 'test' WITH (FORMAT csv)") {
@@ -78,7 +78,7 @@ bool test_copy_to_db_string() {
 
 // Test for select_prefix_string function
 bool test_select_prefix_string() {
-    SQLQuerier *querier = new SQLQuerier("announcement_table", "results_table", "inverse_results_table", "depref_results_table", "full_path_results_table", -1, "test", "bgp-test.conf", false);
+    SQLQuerier<> *querier = new SQLQuerier<>("announcement_table", "results_table", "inverse_results_table", "depref_results_table", "full_path_results_table", -1, "test", "bgp-test.conf", false);
     Prefix<> *p = new Prefix<>("137.99.0.0", "255.255.0.0");
 
     std::string true_results [4] = {
@@ -113,7 +113,7 @@ bool test_select_prefix_string() {
 
 // Test for clear_table_string
 bool test_clear_table_string() {
-    SQLQuerier *querier = new SQLQuerier("announcement_table", "results_table", "inverse_results_table", "depref_results_table", "full_path_results_table", -1, "test", "bgp-test.conf", false);
+    SQLQuerier<> *querier = new SQLQuerier<>("announcement_table", "results_table", "inverse_results_table", "depref_results_table", "full_path_results_table", -1, "test", "bgp-test.conf", false);
 
     if (querier->clear_table_query_string("test_table") != "DROP TABLE IF EXISTS test_table;") {
         std::cerr << "test_clear_table_string failed" << std::endl;
@@ -125,7 +125,7 @@ bool test_clear_table_string() {
 
 // Test for create_table_string
 bool test_create_table_string() {
-    SQLQuerier *querier = new SQLQuerier("announcement_table", "results_table", "inverse_results_table", "depref_results_table", "full_path_results_table", -1, "test", "bgp-test.conf", false);
+    SQLQuerier<> *querier = new SQLQuerier<>("announcement_table", "results_table", "inverse_results_table", "depref_results_table", "full_path_results_table", -1, "test", "bgp-test.conf", false);
 
     std::string true_results [3] = {
         "CREATE TABLE IF NOT EXISTS test_table (stub_asn BIGSERIAL PRIMARY KEY,parent_asn bigint);",

--- a/src/Tests/Tests.cpp
+++ b/src/Tests/Tests.cpp
@@ -42,22 +42,39 @@ BOOST_GLOBAL_FIXTURE( Config );
 BOOST_AUTO_TEST_CASE( Prefix_constructor ) {
         BOOST_CHECK( test_prefix() );
 }
+BOOST_AUTO_TEST_CASE( Prefix_constructor_ipv6 ) {
+        BOOST_CHECK( test_prefix_ipv6() );
+}
 BOOST_AUTO_TEST_CASE( Prefix_to_cidr ) {
         BOOST_CHECK( test_string_to_cidr() );
+}
+BOOST_AUTO_TEST_CASE( Prefix_to_cidr_ipv6 ) {
+        BOOST_CHECK( test_string_to_cidr_ipv6() );
 }
 BOOST_AUTO_TEST_CASE( Prefix_less_than_operator ) {
         BOOST_CHECK( test_prefix_lt_operator() );
 }
+BOOST_AUTO_TEST_CASE( Prefix_less_than_operator_ipv6 ) {
+        BOOST_CHECK( test_prefix_lt_operator_ipv6() );
+}
 BOOST_AUTO_TEST_CASE( Prefix_greater_than_operator ) {
         BOOST_CHECK( test_prefix_gt_operator() );
+}
+BOOST_AUTO_TEST_CASE( Prefix_greater_than_operator_ipv6 ) {
+        BOOST_CHECK( test_prefix_gt_operator_ipv6() );
 }
 BOOST_AUTO_TEST_CASE( Prefix_equivalence_operator ) {
         BOOST_CHECK( test_prefix_eq_operator() );
 }
+BOOST_AUTO_TEST_CASE( Prefix_equivalence_operator_ipv6 ) {
+        BOOST_CHECK( test_prefix_eq_operator_ipv6() );
+}
 BOOST_AUTO_TEST_CASE( Prefix_contained_in_or_equal_to_operator ) {
         BOOST_CHECK( test_prefix_contained_in_or_equal_to_operator() );
 }
-
+BOOST_AUTO_TEST_CASE( Prefix_contained_in_or_equal_to_operator_ipv6 ) {
+        BOOST_CHECK( test_prefix_contained_in_or_equal_to_operator_ipv6() );
+}
 
 // Announcement.h
 BOOST_AUTO_TEST_CASE( Announcement_constructor ) {


### PR DESCRIPTION
IPv6 support was added using templating. Now `AS`, `ASGraph`, `Announcement`, `Extrapolator`, and `SQLQuerier` classes are templated. 
Most functions in `Prefix` are templated and check the IP version like this: `if (std::is_same<Integer, uint128_t>::value)`, where `Integer` is `uint32_t` for IPv4 and `uint128_t` for IPv6.