### PR TITLE
Fixed issue 14

### DIFF
--- a/ROVppAS.cpp
+++ b/ROVppAS.cpp
@@ -501,11 +501,6 @@ void ROVppAS::process_announcements(bool ran) {
                         } else {
                             // Make preventive announcement
                             Announcement preventive_ann = best_alternative_ann;
-                            // Debugging Statements (Delete when done debugging)
-                            // ---------------------------------------------------
-                            bool seven_o_one = bad_neighbors->find(701) != bad_neighbors->end();
-                            bool one_two_nine_nine = bad_neighbors->find(1299) != bad_neighbors->end();
-                            // ---------------------------------------------------
                             preventive_ann.prefix = ann.prefix;
                             preventive_ann.alt = best_alternative_ann.received_from_asn;
                             if (preventive_ann.origin == asn) { preventive_ann.received_from_asn=64514; }
@@ -694,4 +689,3 @@ std::ostream& ROVppAS::stream_blackholes(std:: ostream &os) {
   }
   return os;
 }
-

--- a/ROVppAS.h
+++ b/ROVppAS.h
@@ -47,6 +47,12 @@
 // We're also using this in contrl plane in pass_rovpp
 // Constant was agreed upon with Simulation code.
 #define UNUSED_ASN_FLAG_FOR_BLACKHOLES 64512  
+// This flag is used to denote that along this
+// path an attacker's announcement was seen, but
+// the /16 is still going to be routed through here.
+// Other ROVppASes (just v3) will take this into consideration 
+// making decisions on what path is better.
+#define ATTACKER_ON_ROUTE_FLAG 64570
 
 struct ROVppAS : public AS {
     std::vector<uint32_t> policy_vector;

--- a/ROVppTest.cpp
+++ b/ROVppTest.cpp
@@ -1570,10 +1570,10 @@ bool test_process_announcement2() {
     // are in conflict with a4 and a5 respectively. So the safest one left is a3. When that announcement is sent to process_announcement function it 
     // see that this proposed alternative is not better in terms of relationship to the currently used announcemnt a1. So it will keep using a1.
     if (as.loc_rib->find(p1)->second == a1) {
-        std::cerr << "Prefer relationship over safety" << "\n";
-        return false;
+        return true;
     }
-    return true; 
+    std::cerr << "Should prefer relationship over safety" << "\n";
+    return false; 
 }
 
 


### PR DESCRIPTION
Issue Id: 14
Location: Unknown
Bug: Fixes of other bugs reintroduced routing loops in v3
Cause: turns out the ATTACKER_ON_ROUTE_FLAG was actually a needed flag for preventive announcements to prevent the kind of loop we're noticing now. This is noted in the loop documentation we have on overleaf.
Expected Impacted: need to fix before getting additional v3 and v3 lite results
Discussed: Yes

Had to add the ATTACKER_ON_ROUTE_FLAG back in, but this time properly implemented.
It solves the loop scenario which is a saved full sim run.

Also seems that one of the unit tests was broken for a while. It was the `test_process_announcements2` test.
The return true and false were swapped. Not sure when that happened. 