### PR TITLE
Fixed issue 20

### DIFF
--- a/Announcement.h
+++ b/Announcement.h
@@ -51,6 +51,12 @@ public:
     bool withdraw;              // if this is a withdrawn route
     std::vector<uint32_t> as_path; // stores full as path
     uint32_t roa_validity;       // Inidicates the validity of the announcement (valid = 1; unknown = 2; invalid = 3; both = 4)
+    bool share_special_ann = true;  // This is just for implementation purposes of v2 and v2_lite special case to 
+                                      // to not share blackhole announcements generated as a result from an attacker
+                                      // received from a customer. Had to be added since there's no way to tell
+                                      // at send_all_announcements if the blackhole announcement was created 
+                                      // due to the special case, because we overwrite the received_from_asn with
+                                      // an optimization flag for blackholes in the received_from_asn field.
 
     /** Default constructor
      */
@@ -105,6 +111,7 @@ public:
         policy_index = ann.policy_index;     
         tiebreak_override = ann.tiebreak_override;
         withdraw =  ann.withdraw;              
+        share_special_ann = ann.share_special_ann;
         // this is the important part
         as_path = ann.as_path; 
      }
@@ -134,6 +141,7 @@ public:
         std::swap(a.withdraw, b.withdraw);
         a.as_path.resize(b.as_path.size());
         std::swap(a.as_path, b.as_path);
+        std::swap(a.share_special_ann, b.share_special_ann);
     }
 
     /** Defines the << operator for the Announcements
@@ -155,6 +163,7 @@ public:
             << "TieBrk:\t\t" << std::dec << ann.tiebreak_override << std::endl
             << "From Monitor:\t" << std::boolalpha << ann.from_monitor << std::endl
             << "Withdraw:\t" << std::boolalpha << ann.withdraw << std::endl
+            << "Share Special Ann:\t" << std::boolalpha << ann.share_special_ann << std::endl
             << "AS_PATH\t";
             for (auto i : ann.as_path) { os << i << ' '; }
             os << std::endl;

--- a/Announcement.h
+++ b/Announcement.h
@@ -51,14 +51,8 @@ public:
     bool withdraw;              // if this is a withdrawn route
     std::vector<uint32_t> as_path; // stores full as path
     uint32_t roa_validity;       // Inidicates the validity of the announcement (valid = 1; unknown = 2; invalid = 3; both = 4)
-    bool share_special_ann = true;  // This is just for implementation purposes of v2 and v2_lite special case to 
-                                      // to not share blackhole announcements generated as a result from an attacker
-                                      // received from a customer. Had to be added since there's no way to tell
-                                      // at send_all_announcements if the blackhole announcement was created 
-                                      // due to the special case, because we overwrite the received_from_asn with
-                                      // an optimization flag for blackholes in the received_from_asn field.
-
-    /** Default constructor
+	
+     /** Default constructor
      */
     Announcement(uint32_t aorigin, 
                  uint32_t aprefix, 
@@ -111,7 +105,6 @@ public:
         policy_index = ann.policy_index;     
         tiebreak_override = ann.tiebreak_override;
         withdraw =  ann.withdraw;              
-        share_special_ann = ann.share_special_ann;
         // this is the important part
         as_path = ann.as_path; 
      }
@@ -141,7 +134,6 @@ public:
         std::swap(a.withdraw, b.withdraw);
         a.as_path.resize(b.as_path.size());
         std::swap(a.as_path, b.as_path);
-        std::swap(a.share_special_ann, b.share_special_ann);
     }
 
     /** Defines the << operator for the Announcements
@@ -163,7 +155,6 @@ public:
             << "TieBrk:\t\t" << std::dec << ann.tiebreak_override << std::endl
             << "From Monitor:\t" << std::boolalpha << ann.from_monitor << std::endl
             << "Withdraw:\t" << std::boolalpha << ann.withdraw << std::endl
-            << "Share Special Ann:\t" << std::boolalpha << ann.share_special_ann << std::endl
             << "AS_PATH\t";
             for (auto i : ann.as_path) { os << i << ' '; }
             os << std::endl;

--- a/ROVppAS.cpp
+++ b/ROVppAS.cpp
@@ -465,12 +465,6 @@ void ROVppAS::process_announcements(bool ran) {
                             Announcement blackhole_ann = ann; 
                             // Mark as blackholed and accept this announcement
                             blackholes->insert(blackhole_ann);  // Make copy of annoucement to share as a blackhole ann
-                            // If the blackhole announcement is generated as a result of an attack
-                            // ann from a customer, then we must not share a blackhole announcement (i.e.
-                            // only blackhole, don't share blackhole announcement).
-                            if (customers->find(blackhole_ann.received_from_asn) != customers->end()) {
-                                blackhole_ann.share_special_ann = false;
-                            }
                             blackhole_ann.origin = UNUSED_ASN_FLAG_FOR_BLACKHOLES;
                             blackhole_ann.received_from_asn = UNUSED_ASN_FLAG_FOR_BLACKHOLES;
                             process_announcement(blackhole_ann, false);
@@ -493,24 +487,12 @@ void ROVppAS::process_announcements(bool ran) {
                             Announcement blackhole_ann = ann;  // Make copy of annoucement to share as a blackhole ann
                             // Mark as blackholed and accept this announcement
                             blackholes->insert(blackhole_ann);
-                            // If the blackhole announcement is generated as a result of an attack
-                            // ann from a customer, then we must not share a blackhole announcement (i.e.
-                            // only blackhole, don't share blackhole announcement).
-                            if (customers->find(blackhole_ann.received_from_asn) != customers->end()) {
-                                blackhole_ann.share_special_ann = false;
-                            }
                             blackhole_ann.origin = UNUSED_ASN_FLAG_FOR_BLACKHOLES;
                             blackhole_ann.received_from_asn = UNUSED_ASN_FLAG_FOR_BLACKHOLES;
                             process_announcement(blackhole_ann);
                         } else {
                             // Make preventive announcement
                             Announcement preventive_ann = best_alternative_ann;
-                            // If the preventive announcement is generated as a result of an attack
-                            // ann from a customer, then we must not share a blackhole announcement (i.e.
-                            // only blackhole, don't share blackhole announcement).
-                            if (customers->find(ann.received_from_asn) != customers->end()) {
-                                preventive_ann.share_special_ann = false;
-                            }
                             preventive_ann.prefix = ann.prefix;
                             preventive_ann.alt = best_alternative_ann.received_from_asn;
                             if (preventive_ann.origin == asn) { preventive_ann.received_from_asn=64514; }

--- a/ROVppAS.cpp
+++ b/ROVppAS.cpp
@@ -460,8 +460,6 @@ void ROVppAS::process_announcements(bool ran) {
                         passed_rov->insert(ann);
                         process_announcement(ann, false);
                     } else {
-                        // If it is from a customer, silently drop it
-                        if (customers->find(ann.received_from_asn) != customers->end()) { continue; }
                         Announcement best_alternative_ann = best_alternative_route(ann); 
                         if (best_alternative_ann == ann) { // If no alternative
                             // Mark as blackholed and accept this announcement

--- a/ROVppExtrapolator.cpp
+++ b/ROVppExtrapolator.cpp
@@ -490,9 +490,20 @@ void ROVppExtrapolator::send_all_announcements(uint32_t asn,
         }
         // Propagate all announcements to customers
         if (to_customers) {
-            // Base priority is 0 for provider to customers
-            copy.priority = get_priority(ann.second, i);
-            anns_to_customers.push_back(copy);
+            // Special case to not send blackhole/preventive announcements to customers 
+            // if blackhole is created from an announcement which came from a 
+            // customer. The if conditional is to filter these blackhole/preventive announcements.
+            if (filtered) {
+                if (ann.second.share_special_ann) {
+                    // Base priority is 0 for provider to customers
+                    copy.priority = get_priority(ann.second, i);
+                    anns_to_customers.push_back(copy);
+                } // else don't share the ann
+            } else {
+                // Base priority is 0 for provider to customers
+                copy.priority = get_priority(ann.second, i);
+                anns_to_customers.push_back(copy);
+            }
         }
     }
     

--- a/ROVppExtrapolator.cpp
+++ b/ROVppExtrapolator.cpp
@@ -494,7 +494,7 @@ void ROVppExtrapolator::send_all_announcements(uint32_t asn,
             // if blackhole is created from an announcement which came from a 
             // customer. The if conditional is to filter these blackhole/preventive announcements.
             if (filtered) {
-                if (ann.second.share_special_ann) {
+                if (ann.second.priority > 200) {
                     // Base priority is 0 for provider to customers
                     copy.priority = get_priority(ann.second, i);
                     anns_to_customers.push_back(copy);


### PR DESCRIPTION
Issue Id: 20
Location: ROVppAS::process_anouncements, ROVppExtrapolator::send_all_announcements
Bug: Fixes of other bugs impaired the performance of v2 lite and potentially v2 (noticable in trace_hijacked_adopting)
Cause: This is caused by the special case when an attack annoucement is received from a customer. In this case we should drop the announcement and blackhole. Before it was just dropping the announcement, which created a hidden hijacks.
Expected Impacted: hijack rate is higher than all other ROV++ policies during first 60%
Discussed: Yes

Had to update the dropping of the announcement part and add filtering for blackhole&preventive announcements caused from attacking announcements from customers.